### PR TITLE
feat: decline invitation action + inviter name on Network page

### DIFF
--- a/src/lib/server/trpc/routers/invitations.ts
+++ b/src/lib/server/trpc/routers/invitations.ts
@@ -274,5 +274,32 @@ export const invitationsRouter = router({
 
 		if (!rows[0]) throw new TRPCError({ code: 'NOT_FOUND' });
 		return rows[0];
+	}),
+
+	// El invitado rechaza la invitación — usa ctx.db (superuser) porque RLS no permite
+	// al invitado modificar filas propias (solo el owner puede via RLS)
+	decline: protectedProcedure.input(z.string()).mutation(async ({ ctx, input: invitationId }) => {
+		const me = await ctx.db
+			.select({ email: user.email })
+			.from(user)
+			.where(eq(user.id, ctx.user.id))
+			.limit(1);
+
+		if (!me[0]) throw new TRPCError({ code: 'UNAUTHORIZED' });
+
+		const rows = await ctx.db
+			.update(projectInvitation)
+			.set({ status: 'cancelled' })
+			.where(
+				and(
+					eq(projectInvitation.id, invitationId),
+					eq(projectInvitation.invitedEmail, me[0].email),
+					eq(projectInvitation.status, 'pending')
+				)
+			)
+			.returning({ id: projectInvitation.id });
+
+		if (!rows[0]) throw new TRPCError({ code: 'NOT_FOUND' });
+		return rows[0];
 	})
 });

--- a/src/routes/(app)/network/+page.server.ts
+++ b/src/routes/(app)/network/+page.server.ts
@@ -1,6 +1,7 @@
-import { eq, and } from 'drizzle-orm';
+import { eq, and, gt } from 'drizzle-orm';
 import { db } from '$lib/server/db';
 import { projectInvitation } from '$lib/server/db/schemas/invitations.schema';
+import { user } from '$lib/server/db/auth.schema';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async (event) => {
@@ -14,13 +15,16 @@ export const load: PageServerLoad = async (event) => {
 			expiresAt: projectInvitation.expiresAt,
 			createdAt: projectInvitation.createdAt,
 			projectId: projectInvitation.projectId,
-			projectTitle: projectInvitation.projectTitle
+			projectTitle: projectInvitation.projectTitle,
+			invitedByName: user.name
 		})
 		.from(projectInvitation)
+		.leftJoin(user, eq(user.id, projectInvitation.invitedBy))
 		.where(
 			and(
 				eq(projectInvitation.invitedEmail, userEmail),
-				eq(projectInvitation.status, 'pending')
+				eq(projectInvitation.status, 'pending'),
+				gt(projectInvitation.expiresAt, new Date())
 			)
 		)
 		.orderBy(projectInvitation.createdAt);

--- a/src/routes/(app)/network/+page.svelte
+++ b/src/routes/(app)/network/+page.svelte
@@ -13,6 +13,7 @@
 	let { data }: { data: PageData } = $props();
 
 	let accepting = $state<string | null>(null);
+	let declining = $state<string | null>(null);
 	let error = $state('');
 
 	async function accept(token: string) {
@@ -27,6 +28,19 @@
 			accepting = null;
 		}
 	}
+
+	async function decline(id: string) {
+		declining = id;
+		error = '';
+		try {
+			await trpc.invitations.decline.mutate(id);
+			await invalidateAll();
+		} catch (e: unknown) {
+			error = e instanceof Error ? e.message : 'Error declining invitation';
+		} finally {
+			declining = null;
+		}
+	}
 </script>
 
 <div class="mx-auto max-w-2xl px-6 py-10">
@@ -38,37 +52,54 @@
 		</h2>
 
 		{#if data.invitations.length === 0}
-			<p class="font-sans text-sm text-ink-muted dark:text-dark-ink-muted">
-				You have no pending invitations.
-			</p>
+			<div class="flex flex-col items-center justify-center rounded-xl border border-dashed border-paper-border py-12 dark:border-dark-paper-border">
+				<svg width="28" height="28" viewBox="0 0 24 24" fill="none" class="mb-2 text-ink-faint dark:text-dark-ink-faint">
+					<path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+					<circle cx="9" cy="7" r="4" stroke="currentColor" stroke-width="1.5"/>
+					<path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+				</svg>
+				<p class="font-sans text-sm text-ink-muted dark:text-dark-ink-muted">
+					No pending invitations.
+				</p>
+			</div>
 		{:else}
 			<ul class="flex flex-col gap-3">
 				{#each data.invitations as inv (inv.id)}
-					<li class="flex items-center justify-between rounded-xl border border-paper-border bg-paper px-4 py-3 dark:border-dark-paper-border dark:bg-dark-paper">
-						<div class="min-w-0">
+					<li class="flex items-center justify-between gap-4 rounded-xl border border-paper-border bg-paper px-4 py-3 dark:border-dark-paper-border dark:bg-dark-paper">
+						<div class="min-w-0 flex-1">
 							<p class="truncate font-sans text-sm font-medium text-ink dark:text-dark-ink">
-								{inv.projectTitle}
+								{inv.projectTitle ?? 'Untitled project'}
 							</p>
 							<p class="mt-0.5 font-sans text-xs text-ink-faint dark:text-dark-ink-faint">
-								{roleLabel[inv.role] ?? inv.role} · expires {new Intl.DateTimeFormat('en', {
-									day: 'numeric',
-									month: 'short'
-								}).format(new Date(inv.expiresAt))}
+								{roleLabel[inv.role] ?? inv.role}
+								{#if inv.invitedByName}
+									· invited by {inv.invitedByName}
+								{/if}
+								· expires {new Intl.DateTimeFormat('en', { day: 'numeric', month: 'short' }).format(new Date(inv.expiresAt))}
 							</p>
 						</div>
-						<button
-							onclick={() => accept(inv.token)}
-							disabled={accepting === inv.token}
-							class="ml-4 shrink-0 rounded-lg bg-accent px-4 py-1.5 font-sans text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
-						>
-							{accepting === inv.token ? 'Accepting…' : 'Accept'}
-						</button>
+						<div class="flex shrink-0 items-center gap-2">
+							<button
+								onclick={() => decline(inv.id)}
+								disabled={declining === inv.id || accepting === inv.token}
+								class="rounded-lg border border-paper-border px-3 py-1.5 font-sans text-sm text-ink-muted transition-colors hover:border-red-200 hover:bg-red-50 hover:text-red-600 disabled:opacity-50 dark:border-dark-paper-border dark:text-dark-ink-muted dark:hover:bg-red-900/10 dark:hover:text-red-400"
+							>
+								{declining === inv.id ? 'Declining…' : 'Decline'}
+							</button>
+							<button
+								onclick={() => accept(inv.token)}
+								disabled={accepting === inv.token || declining === inv.id}
+								class="rounded-lg bg-accent px-4 py-1.5 font-sans text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+							>
+								{accepting === inv.token ? 'Accepting…' : 'Accept'}
+							</button>
+						</div>
 					</li>
 				{/each}
 			</ul>
 
 			{#if error}
-				<p class="mt-3 font-sans text-sm text-red-600">{error}</p>
+				<p class="mt-3 font-sans text-sm text-red-600 dark:text-red-400">{error}</p>
 			{/if}
 		{/if}
 	</section>


### PR DESCRIPTION
- Add invitations.decline tRPC procedure for the invitee (uses superuser db since RLS only allows owner mutations on project_invitation)
- Network page now shows the inviter's name and filters out expired invitations at query time (gt expiresAt > now)
- Decline button added alongside Accept with optimistic disabled state