### PR TITLE
feat: show open comments badge on project detail page header

### DIFF
--- a/src/routes/(app)/projects/[id]/+page.server.ts
+++ b/src/routes/(app)/projects/[id]/+page.server.ts
@@ -1,17 +1,17 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { project, projectCollaborator } from '$lib/server/db/schemas/projects.schema';
-import { document } from '$lib/server/db/schemas/documents.schema';
+import { document, documentVersion } from '$lib/server/db/schemas/documents.schema';
+import { comment } from '$lib/server/db/schemas/comments.schema';
 import { projectInvitation } from '$lib/server/db/schemas/invitations.schema';
 import { projectRequirement } from '$lib/server/db/schemas/requirements.schema';
-import { eq, desc, and, count, sql, inArray } from 'drizzle-orm';
-import { documentVersion } from '$lib/server/db/schemas/documents.schema';
+import { eq, desc, and, count, sql, inArray, isNull } from 'drizzle-orm';
 
 export const load: PageServerLoad = async (event) => {
 	const projectId = event.params.id;
 	const userId = event.locals.user!.id;
 
-	const [proj, documents, collaborators, invitations, requirementCounts] = await Promise.all([
+	const [proj, documents, collaborators, invitations, requirementCounts, openCommentsCount] = await Promise.all([
 		event.locals.withRLS((db) =>
 			db.select().from(project).where(eq(project.id, projectId)).limit(1)
 		),
@@ -80,7 +80,21 @@ export const load: PageServerLoad = async (event) => {
 				})
 				.from(projectRequirement)
 				.where(eq(projectRequirement.projectId, projectId))
-		) as Promise<{ total: number; fulfilled: number; requiredTotal: number; requiredFulfilled: number }[]>
+		) as Promise<{ total: number; fulfilled: number; requiredTotal: number; requiredFulfilled: number }[]>,
+
+		event.locals.withRLS((db) =>
+			db
+				.select({ value: count() })
+				.from(comment)
+				.innerJoin(document, eq(document.id, comment.documentId))
+				.where(
+					and(
+						eq(document.projectId, projectId),
+						eq(comment.status, 'open'),
+						isNull(comment.parentCommentId)
+					)
+				)
+		)
 	]);
 
 	if (!proj[0]) error(404, 'Proyecto no encontrado');
@@ -96,6 +110,7 @@ export const load: PageServerLoad = async (event) => {
 		invitations,
 		myRole,
 		isOwner: proj[0].ownerId === userId,
-		requirementCounts: reqCounts
+		requirementCounts: reqCounts,
+		openComments: openCommentsCount[0]?.value ?? 0
 	};
 };

--- a/src/routes/(app)/projects/[id]/+page.svelte
+++ b/src/routes/(app)/projects/[id]/+page.svelte
@@ -691,6 +691,18 @@
 
 			</div>
 			<div class="hidden shrink-0 items-center gap-2 sm:flex">
+				{#if data.openComments > 0}
+					<a
+						href="/projects/{data.project.id}/review"
+						class="flex items-center gap-1 rounded-full bg-amber-100 px-2.5 py-1 font-sans text-xs font-medium text-amber-700 transition-colors hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-400 dark:hover:bg-amber-900/50"
+						title="View open comments"
+					>
+						<svg width="11" height="11" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+							<path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+						</svg>
+						{data.openComments}
+					</a>
+				{/if}
 				<a
 					href="/api/projects/{data.project.id}/export"
 					download


### PR DESCRIPTION
Adds the same amber badge as the project card, linking to /review, in the top-right header alongside Export and the status pill. Server load now queries the open comment count for the project.