### PR TITLE
feat: per-document open comments badge in project document list

### DIFF
--- a/src/routes/(app)/projects/[id]/+page.server.ts
+++ b/src/routes/(app)/projects/[id]/+page.server.ts
@@ -11,7 +11,7 @@ export const load: PageServerLoad = async (event) => {
 	const projectId = event.params.id;
 	const userId = event.locals.user!.id;
 
-	const [proj, documents, collaborators, invitations, requirementCounts, openCommentsCount] = await Promise.all([
+	const [proj, documents, collaborators, invitations, requirementCounts, openCommentsCount, docCommentCounts] = await Promise.all([
 		event.locals.withRLS((db) =>
 			db.select().from(project).where(eq(project.id, projectId)).limit(1)
 		),
@@ -94,6 +94,21 @@ export const load: PageServerLoad = async (event) => {
 						isNull(comment.parentCommentId)
 					)
 				)
+		),
+
+		event.locals.withRLS((db) =>
+			db
+				.select({ documentId: comment.documentId, value: count() })
+				.from(comment)
+				.innerJoin(document, eq(document.id, comment.documentId))
+				.where(
+					and(
+						eq(document.projectId, projectId),
+						eq(comment.status, 'open'),
+						isNull(comment.parentCommentId)
+					)
+				)
+				.groupBy(comment.documentId)
 		)
 	]);
 
@@ -103,6 +118,10 @@ export const load: PageServerLoad = async (event) => {
 
 	const reqCounts = (requirementCounts as { total: number; fulfilled: number; requiredTotal: number; requiredFulfilled: number }[])[0] ?? { total: 0, fulfilled: 0, requiredTotal: 0, requiredFulfilled: 0 };
 
+	const openCommentsByDoc = Object.fromEntries(
+		docCommentCounts.map((r) => [r.documentId, r.value])
+	);
+
 	return {
 		project: proj[0],
 		documents,
@@ -111,6 +130,7 @@ export const load: PageServerLoad = async (event) => {
 		myRole,
 		isOwner: proj[0].ownerId === userId,
 		requirementCounts: reqCounts,
-		openComments: openCommentsCount[0]?.value ?? 0
+		openComments: openCommentsCount[0]?.value ?? 0,
+		openCommentsByDoc
 	};
 };

--- a/src/routes/(app)/projects/[id]/+page.svelte
+++ b/src/routes/(app)/projects/[id]/+page.svelte
@@ -934,6 +934,19 @@
 										(window.location.href = `/projects/${data.project.id}/documents/${doc.id}`)}
 								/>
 							</div>
+							{#if (data.openCommentsByDoc[doc.id] ?? 0) > 0}
+								<a
+									href="/projects/{data.project.id}/review#doc-{doc.id}"
+									onclick={(e) => e.stopPropagation()}
+									class="mr-1 flex shrink-0 items-center gap-0.5 rounded-full bg-amber-100 px-2 py-0.5 font-sans text-xs font-medium text-amber-700 opacity-0 transition-opacity group-hover:opacity-100 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-400 dark:hover:bg-amber-900/50"
+									title="View open comments"
+								>
+									<svg width="9" height="9" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+										<path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+									</svg>
+									{data.openCommentsByDoc[doc.id]}
+								</a>
+							{/if}
 							{#if canEdit}
 								<div class="relative">
 									<button

--- a/src/routes/(app)/projects/[id]/review/+page.svelte
+++ b/src/routes/(app)/projects/[id]/review/+page.svelte
@@ -78,7 +78,7 @@
 	{:else}
 		<div class="flex flex-col gap-8">
 			{#each data.documents as doc (doc.documentId)}
-				<section>
+				<section id="doc-{doc.documentId}">
 					<!-- Document heading -->
 					<div class="mb-3 flex items-center gap-2">
 						<a


### PR DESCRIPTION
Shows an amber pill with comment count next to each document row, visible on hover, linking to /review#doc-[id]. The review page now has id anchors on each document section so the link scrolls directly to the right document. Server load adds a grouped comment count query.