### PR TITLE
fix: use dynamic env for SCIPY_SERVICE_URL and SCIPY_API_KEY

### DIFF
--- a/src/lib/server/scipy.ts
+++ b/src/lib/server/scipy.ts
@@ -1,4 +1,7 @@
-import { SCIPY_SERVICE_URL, SCIPY_API_KEY } from '$env/static/private';
+import { env } from '$env/dynamic/private';
+
+const SCIPY_SERVICE_URL = env.SCIPY_SERVICE_URL ?? '';
+const SCIPY_API_KEY = env.SCIPY_API_KEY ?? '';
 
 type DatasetRef = {
 	bucket: string;


### PR DESCRIPTION
Static env vars are baked at build time — the Dockerfile placeholder was overriding any runtime value. Switching to \$env/dynamic/private so Dokploy / docker-compose env vars take effect without a rebuild.