### PR TITLE
fix: downgrade weasyprint to 61.2 to avoid Python 3.12 transform bug

### DIFF
--- a/scipy-service/requirements.txt
+++ b/scipy-service/requirements.txt
@@ -1,4 +1,4 @@
 fastapi==0.115.6
 uvicorn==0.32.1
-weasyprint==62.3
+weasyprint==61.2
 requests==2.32.3


### PR DESCRIPTION
WeasyPrint 62.x has an internal bug with Python 3.12 where 'super' object has no attribute 'transform', causing all HTML renders to fail.