### PR TITLE
fix: use python:3.11-slim for scipy-service to fix WeasyPrint compati…

### DIFF
--- a/scipy-service/Dockerfile
+++ b/scipy-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.11-slim
 
 # WeasyPrint system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/scipy-service/requirements.txt
+++ b/scipy-service/requirements.txt
@@ -1,4 +1,4 @@
 fastapi==0.115.6
 uvicorn==0.32.1
-weasyprint==61.2
+weasyprint==62.3
 requests==2.32.3


### PR DESCRIPTION
…bility

Python 3.12 + WeasyPrint 62.x has a 'super has no attribute transform' bug. Python 3.12 + WeasyPrint 61.x has a pydyf API incompatibility. Python 3.11 + WeasyPrint 62.3 is the stable combination.