### PR TITLE
fix: pin pydyf==0.10.0 to restore WeasyPrint transform compatibility

### DIFF
--- a/scipy-service/requirements.txt
+++ b/scipy-service/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.115.6
 uvicorn==0.32.1
 weasyprint==62.3
+pydyf==0.10.0
 requests==2.32.3


### PR DESCRIPTION
pydyf 0.11+ removed the transform() method from its Stream class. WeasyPrint 62.3 still calls super().transform() — pinning pydyf to 0.10.0 restores the method and fixes PDF rendering.