### PR TITLE
fix(auth): share session cookie across subdomains via COOKIE_DOMAIN

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -71,6 +71,8 @@ services:
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
       AWS_KMS_KEY_ID: ${AWS_KMS_KEY_ID}
+      # Cross-app auth (shared cookie across subdomains)
+      COOKIE_DOMAIN: ${COOKIE_DOMAIN:-}
       # Notifications
       SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL:-}
     #ports:
@@ -98,6 +100,8 @@ services:
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET}
       DATABASE_URL: ${DATABASE_URL}
       MIGRATION_DATABASE_URL: ${MIGRATION_DATABASE_URL}
+      COOKIE_DOMAIN: ${COOKIE_DOMAIN:-}
+      TRUSTED_ORIGINS: ${TRUSTED_ORIGINS:-}
     networks:
       - scholio-network
 

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -30,6 +30,23 @@ export const auth = betterAuth({
       clientSecret: env.GITHUB_CLIENT_SECRET
     }
   },
+  advanced: {
+    // Cookie compartida entre subdominios (ej: .scholio.review).
+    // En dev COOKIE_DOMAIN está vacío → cookie sin domain, solo funciona en localhost.
+    ...(env.COOKIE_DOMAIN
+      ? {
+          cookies: {
+            session_token: {
+              attributes: {
+                domain: env.COOKIE_DOMAIN,
+                sameSite: 'lax' as const,
+                secure: true
+              }
+            }
+          }
+        }
+      : {})
+  },
   plugins: [
     twoFactor({ issuer: 'Scholio' }),
     sveltekitCookies(getRequestEvent) // make sure this is the last plugin in the array


### PR DESCRIPTION
Set cookie domain attribute on session_token when COOKIE_DOMAIN is defined, so scholio.review and librarian.scholio.review share the same auth cookie. Also pass COOKIE_DOMAIN and TRUSTED_ORIGINS to librarian service in docker-compose.