### PR TITLE
fix: use h-full instead of calc(100vh-57px) in document editor

### DIFF
--- a/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
+++ b/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
@@ -2046,7 +2046,7 @@
 		{/snippet}
 
 		<!-- Main layout -->
-		<div class="flex overflow-hidden" style="height: calc(100vh - 57px)">
+		<div class="flex h-full overflow-hidden">
 			{#if viewMode === 'split'}
 				<!-- Split: editor left, preview right -->
 				<div class="relative flex flex-1 flex-col overflow-hidden">


### PR DESCRIPTION
The hardcoded calc didn't account for the footer height, causing the editor to overflow the main container and pushing the chat input below the visible area.