### PR TITLE
feat: stop button for AI streaming — abort in-flight SSE request

### DIFF
--- a/src/lib/components/ai/AiEditorPanel.svelte
+++ b/src/lib/components/ai/AiEditorPanel.svelte
@@ -71,6 +71,11 @@
 	let loading = $state(false);
 	let loadingHint = $state('Thinking…');
 	let error = $state('');
+	let abortController = $state<AbortController | null>(null);
+
+	function stopStream() {
+		abortController?.abort();
+	}
 	let historyLoaded = $state(false);
 	let messagesEl = $state<HTMLDivElement | null>(null);
 
@@ -137,6 +142,8 @@
 
 		// Streaming assistant message placeholder
 		let assistantIdx = -1;
+		const controller = new AbortController();
+		abortController = controller;
 
 		try {
 			const res = await fetch(
@@ -152,7 +159,8 @@
 						conversationId,
 						message: text,
 						...(!orgId && selectedModel ? { modelOverride: selectedModel } : {})
-					})
+					}),
+					signal: controller.signal
 				}
 			);
 
@@ -224,15 +232,19 @@
 				// no-op: done event handled it
 			}
 		} catch (e: unknown) {
-			// Remove user message on hard failure
-			if (assistantIdx === -1) {
-				messages = messages.slice(0, -1);
+			if (e instanceof Error && e.name === 'AbortError') {
+				// User stopped — keep whatever was streamed
 			} else {
-				messages = messages.filter((_, i) => i !== assistantIdx);
-				messages = messages.slice(0, -1);
+				if (assistantIdx === -1) {
+					messages = messages.slice(0, -1);
+				} else {
+					messages = messages.filter((_, i) => i !== assistantIdx);
+					messages = messages.slice(0, -1);
+				}
+				error = e instanceof Error ? e.message : 'Request failed';
 			}
-			error = e instanceof Error ? e.message : 'Request failed';
 		} finally {
+			abortController = null;
 			loading = false;
 		}
 	}
@@ -434,17 +446,30 @@
 				class="flex-1 resize-none bg-transparent font-sans text-sm text-ink placeholder:text-ink-faint focus:outline-none dark:text-dark-ink"
 				style="max-height: 120px;"
 			></textarea>
-			<button
-				type="button"
-				onclick={send}
-				disabled={!input.trim() || loading}
-				class="shrink-0 rounded-lg bg-accent p-1.5 text-white transition-colors hover:bg-accent-hover disabled:opacity-40"
-				aria-label="Send"
-			>
-				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-					<path d="M22 2L11 13M22 2L15 22l-4-9-9-4 20-7z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-				</svg>
-			</button>
+			{#if loading}
+				<button
+					type="button"
+					onclick={stopStream}
+					aria-label="Stop"
+					class="shrink-0 rounded-lg border border-paper-border bg-paper p-1.5 text-ink-muted transition-colors hover:border-red-300 hover:bg-red-50 hover:text-red-500 dark:border-dark-paper-border dark:bg-dark-paper dark:text-dark-ink-muted dark:hover:border-red-700/50 dark:hover:bg-red-950/30 dark:hover:text-red-400"
+				>
+					<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+						<rect x="5" y="5" width="14" height="14" rx="2"/>
+					</svg>
+				</button>
+			{:else}
+				<button
+					type="button"
+					onclick={send}
+					disabled={!input.trim()}
+					class="shrink-0 rounded-lg bg-accent p-1.5 text-white transition-colors hover:bg-accent-hover disabled:opacity-40"
+					aria-label="Send"
+				>
+					<svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+						<path d="M22 2L11 13M22 2L15 22l-4-9-9-4 20-7z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+					</svg>
+				</button>
+			{/if}
 		</div>
 	</div>
 </div>

--- a/src/lib/server/trpc/routers/ai.ts
+++ b/src/lib/server/trpc/routers/ai.ts
@@ -1487,7 +1487,8 @@ type StreamedToolCall = {
 async function parseStreamingResponse(
   res: Response,
   onTextDelta: (chunk: string) => void,
-  onToolStart?: (name: string) => void
+  onToolStart?: (name: string) => void,
+  signal?: AbortSignal
 ): Promise<{
   content: string;
   toolCalls: StreamedToolCall[];
@@ -1507,6 +1508,7 @@ async function parseStreamingResponse(
 
   try {
     while (true) {
+      if (signal?.aborted) break;
       const { done, value } = await reader.read();
       if (done) break;
       buf += decoder.decode(value, { stream: true });
@@ -1577,7 +1579,8 @@ export async function runAgentLoopSSE(
   projectId: string,
   apiKey: string,
   model: string,
-  write: (event: object) => void
+  write: (event: object) => void,
+  signal?: AbortSignal
 ): Promise<{ content: string; pendingActions: PendingAction[]; docsUsed: { id: string; title: string }[]; inputTokens: number; outputTokens: number }> {
   const messages: OAMessage[] = [
     ...history.map((m) => ({ role: m.role as 'user' | 'assistant', content: m.content })),
@@ -1590,6 +1593,7 @@ export async function runAgentLoopSSE(
   let totalOutputTokens = 0;
 
   for (let i = 0; i < MAX_AGENT_ITERATIONS; i++) {
+    if (signal?.aborted) break;
     const res = await fetch(OPENROUTER_URL, {
       method: 'POST',
       headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json', ...extraHeaders },
@@ -1601,14 +1605,16 @@ export async function runAgentLoopSSE(
         tool_choice: 'auto',
         stream: true,
         stream_options: { include_usage: true }
-      })
+      }),
+      signal
     });
     if (!res.ok) await throwProviderError(res);
 
     const { content, toolCalls, inputTokens, outputTokens, finishReason } = await parseStreamingResponse(
       res,
       (chunk) => write({ type: 'text_delta', content: chunk }),
-      (name) => write({ type: 'tool_start', name })
+      (name) => write({ type: 'tool_start', name }),
+      signal
     );
     totalInputTokens += inputTokens;
     totalOutputTokens += outputTokens;
@@ -1679,7 +1685,8 @@ export async function runEditorAgentLoopSSE(
   apiKey: string,
   model: string,
   toolCtx: EditorToolContext,
-  write: (event: object) => void
+  write: (event: object) => void,
+  signal?: AbortSignal
 ): Promise<{ content: string; pendingEditorActions: PendingEditorAction[]; pendingActions: PendingAction[]; inputTokens: number; outputTokens: number }> {
   const systemPrompt = `${EDITOR_SYSTEM_PROMPT}\n\n---\n\n## Document: "${documentTitle}"\n\n${documentContent}`;
   const messages: OAMessage[] = [
@@ -1693,6 +1700,7 @@ export async function runEditorAgentLoopSSE(
   let totalOutputTokens = 0;
 
   for (let i = 0; i < 4; i++) {
+    if (signal?.aborted) break;
     const res = await fetch(OPENROUTER_URL, {
       method: 'POST',
       headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json', ...extraHeaders },
@@ -1704,14 +1712,16 @@ export async function runEditorAgentLoopSSE(
         tool_choice: 'auto',
         stream: true,
         stream_options: { include_usage: true }
-      })
+      }),
+      signal
     });
     if (!res.ok) await throwProviderError(res);
 
     const { content, toolCalls, inputTokens, outputTokens, finishReason } = await parseStreamingResponse(
       res,
       (chunk) => write({ type: 'text_delta', content: chunk }),
-      (name) => write({ type: 'tool_start', name })
+      (name) => write({ type: 'tool_start', name }),
+      signal
     );
     totalInputTokens += inputTokens;
     totalOutputTokens += outputTokens;

--- a/src/routes/(app)/projects/[id]/ai/+page.svelte
+++ b/src/routes/(app)/projects/[id]/ai/+page.svelte
@@ -30,6 +30,11 @@
 	let sendError = $state<string | null>(null);
 	let thinkingHint = $state('Thinking…');
 	let streamingMsgId = $state<string | null>(null);
+	let abortController = $state<AbortController | null>(null);
+
+	function stopStream() {
+		abortController?.abort();
+	}
 
 	// Pending actions from the latest agent response (in-memory, cleared on next send)
 	let pendingActions = $state<PendingAction[]>([]);
@@ -85,6 +90,8 @@
 		scrollToBottom();
 
 		let localStreamId: string | null = null;
+		const controller = new AbortController();
+		abortController = controller;
 
 		try {
 			const res = await fetch(`/api/projects/${data.project.id}/chat`, {
@@ -94,7 +101,8 @@
 					message: text,
 					conversationId: activeConvId ?? undefined,
 					modelOverride: modelOverride ?? undefined
-				})
+				}),
+				signal: controller.signal
 			});
 
 			if (!res.ok || !res.body) {
@@ -179,10 +187,15 @@
 				}
 			}
 		} catch (e) {
-			messages = messages.filter((m) => m.id !== localStreamId && m.id !== tempUserId);
-			streamingMsgId = null;
-			sendError = e instanceof Error ? e.message : 'Request failed';
+			if (e instanceof Error && e.name === 'AbortError') {
+				// User stopped — keep whatever was streamed, just stop loading
+			} else {
+				messages = messages.filter((m) => m.id !== localStreamId && m.id !== tempUserId);
+				streamingMsgId = null;
+				sendError = e instanceof Error ? e.message : 'Request failed';
+			}
 		} finally {
+			abortController = null;
 			sending = false;
 		}
 	}
@@ -573,17 +586,30 @@
 						class="flex-1 resize-none bg-transparent font-sans text-sm text-ink placeholder:text-ink-faint focus:outline-none dark:text-dark-ink"
 						style="max-height: 160px; overflow-y: auto;"
 					></textarea>
-					<button
-						type="button"
-						onclick={send}
-						disabled={sending || !input.trim()}
-						aria-label="Enviar"
-						class="shrink-0 rounded-lg bg-accent p-2 text-white transition-colors hover:bg-accent-hover disabled:opacity-40"
-					>
-						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-							<path d="M22 2L11 13M22 2L15 22l-4-9-9-4 20-7z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
-						</svg>
-					</button>
+					{#if sending}
+						<button
+							type="button"
+							onclick={stopStream}
+							aria-label="Detener"
+							class="shrink-0 rounded-lg border border-paper-border bg-paper p-2 text-ink-muted transition-colors hover:border-red-300 hover:bg-red-50 hover:text-red-500 dark:border-dark-paper-border dark:bg-dark-paper dark:text-dark-ink-muted dark:hover:border-red-700/50 dark:hover:bg-red-950/30 dark:hover:text-red-400"
+						>
+							<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+								<rect x="5" y="5" width="14" height="14" rx="2"/>
+							</svg>
+						</button>
+					{:else}
+						<button
+							type="button"
+							onclick={send}
+							disabled={!input.trim()}
+							aria-label="Enviar"
+							class="shrink-0 rounded-lg bg-accent p-2 text-white transition-colors hover:bg-accent-hover disabled:opacity-40"
+						>
+							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+								<path d="M22 2L11 13M22 2L15 22l-4-9-9-4 20-7z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+							</svg>
+						</button>
+					{/if}
 				</div>
 				<div class="mt-2 flex items-center justify-between">
 					<p class="font-sans text-xs text-ink-faint dark:text-dark-ink-faint">

--- a/src/routes/api/projects/[id]/chat/+server.ts
+++ b/src/routes/api/projects/[id]/chat/+server.ts
@@ -104,7 +104,8 @@ export const POST: RequestHandler = async (event) => {
         projectId,
         apiKey,
         effectiveModel,
-        send
+        send,
+        event.request.signal
       );
 
       const msgId = crypto.randomUUID();
@@ -142,9 +143,10 @@ export const POST: RequestHandler = async (event) => {
         pendingActions: result.pendingActions.length > 0 ? result.pendingActions : undefined
       });
     } catch (e) {
+      if (e instanceof Error && e.name === 'AbortError') return;
       const msg = e instanceof Error ? e.message : 'Unknown error';
       const isPreCondition = e && typeof e === 'object' && 'code' in e && (e as { code: string }).code === 'PRECONDITION_FAILED';
-      send({ type: 'error', message: isPreCondition ? msg : msg, kind: isPreCondition ? 'system' : 'banner' });
+      send({ type: 'error', message: msg, kind: isPreCondition ? 'system' : 'banner' });
     } finally {
       await writer.close().catch(() => {});
     }

--- a/src/routes/api/projects/[id]/documents/[docId]/chat/+server.ts
+++ b/src/routes/api/projects/[id]/documents/[docId]/chat/+server.ts
@@ -119,7 +119,8 @@ export const POST: RequestHandler = async (event) => {
           projectId,
           documentId
         },
-        send
+        send,
+        event.request.signal
       );
 
       const msgId = crypto.randomUUID();
@@ -156,6 +157,7 @@ export const POST: RequestHandler = async (event) => {
         pendingActions: result.pendingActions.length > 0 ? result.pendingActions : undefined
       });
     } catch (e) {
+      if (e instanceof Error && e.name === 'AbortError') return;
       const msg = e instanceof Error ? e.message : 'Unknown error';
       const isPreCondition = e && typeof e === 'object' && 'code' in e && (e as { code: string }).code === 'PRECONDITION_FAILED';
       send({ type: 'error', message: msg, kind: isPreCondition ? 'system' : 'banner' });


### PR DESCRIPTION
AbortController per send() call; signal threaded through fetch → runAgentLoopSSE → parseStreamingResponse so the OpenRouter request is cancelled server-side on abort. Endpoints catch AbortError and skip DB write + error SSE event. Client keeps whatever text was already streamed; no error banner shown on user stop. Stop button (square icon) replaces send button while streaming in both the project AI page and the editor panel.