### PR TITLE
fix: citation autocomplete trigger on any keyboard layout + robust re…

### DIFF
--- a/src/lib/components/editor/MarkdownEditor.svelte
+++ b/src/lib/components/editor/MarkdownEditor.svelte
@@ -671,46 +671,26 @@
 			dragAutoScroll()
 		];
 
-		// Trigger completion immediately for non-word chars that CM6 won't auto-trigger on:
-		//   # after [[  → heading completion
-		//   : after [[doc → wikilink completion
-		//   @ after [[  → citation completion
-		exts.push(keymap.of([
-			{
-				key: '#',
-				run(view) {
-					const cursor = view.state.selection.main.head;
-					const before = view.state.doc.sliceString(Math.max(0, cursor - 2), cursor);
-					if (before !== '[[') return false;
-					view.dispatch({ changes: { from: cursor, insert: '#' }, selection: { anchor: cursor + 1 } });
-					startCompletion(view);
-					return true;
-				}
-			},
-			{
-				key: ':',
-				run(view) {
-					const cursor = view.state.selection.main.head;
-					const before = view.state.doc.sliceString(Math.max(0, cursor - 50), cursor);
-					// [[doc: → wikilink  or  [[@citeKey: → subnote
-					if (!before.endsWith('[[doc') && !/\[\[@[\w.-]+$/.test(before)) return false;
-					view.dispatch({ changes: { from: cursor, insert: ':' }, selection: { anchor: cursor + 1 } });
-					startCompletion(view);
-					return true;
-				}
-			},
-			{
-				key: '@',
-				run(view) {
-					const cursor = view.state.selection.main.head;
-					const before = view.state.doc.sliceString(Math.max(0, cursor - 2), cursor);
-					if (before !== '[[') return false;
-					view.dispatch({ changes: { from: cursor, insert: '@' }, selection: { anchor: cursor + 1 } });
-					startCompletion(view);
-					return true;
-				}
+		// Trigger completion for non-word chars that CM6 activateOnTyping won't handle.
+		// We use inputHandler (not keymap) so it fires regardless of keyboard layout —
+		// keymap key names like '@' don't match on AltGr keyboards (Spanish, German…).
+		exts.push(EditorView.inputHandler.of((view, from, to, insert) => {
+			if (insert === '@' || insert === '#') {
+				const before = view.state.doc.sliceString(Math.max(0, from - 2), from);
+				if (before !== '[[') return false;
+				view.dispatch({ changes: { from, to, insert }, selection: { anchor: from + 1 } });
+				startCompletion(view);
+				return true;
 			}
-		]));
+			if (insert === ':') {
+				const before = view.state.doc.sliceString(Math.max(0, from - 50), from);
+				if (!before.endsWith('[[doc') && !/\[\[@[\w.-]+$/.test(before)) return false;
+				view.dispatch({ changes: { from, to, insert: ':' }, selection: { anchor: from + 1 } });
+				startCompletion(view);
+				return true;
+			}
+			return false;
+		}));
 
 		if (isDarkMode()) exts.push(oneDark);
 		return exts;

--- a/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
+++ b/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
@@ -314,8 +314,14 @@
 	async function loadRefs() {
 		if (refsLoaded) return;
 		try {
-			const rows = await trpc.references.listWithSubnotes.query(data.document.projectId);
-			projectRefs = rows as CiteRef[];
+			let rows: CiteRef[];
+			try {
+				rows = (await trpc.references.listWithSubnotes.query(data.document.projectId)) as CiteRef[];
+			} catch {
+				// Fallback if reference_subnote table not yet migrated
+				rows = (await trpc.references.list.query(data.document.projectId)) as CiteRef[];
+			}
+			projectRefs = rows;
 			refsLoaded = true;
 		} catch {
 			/* non-critical */


### PR DESCRIPTION
…fs loading

Replace keymap.of special-char handlers with EditorView.inputHandler. keymap 'key: @' / 'key: #' / 'key: :' are matched against CM6's normalised key name which includes modifier prefixes (Alt-, Ctrl-) — on AltGr keyboards (Spanish, German, etc.) typing @ sends Alt-@ and the handler never fired. inputHandler receives the raw inserted string, bypassing modifier normalisation.

loadRefs now falls back to the plain list procedure if listWithSubnotes fails (e.g. reference_subnote table not yet migrated).