### PR TITLE
add project-level citation style with document inheritance

### DIFF
--- a/drizzle/0002_project_citation_style.sql
+++ b/drizzle/0002_project_citation_style.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "scholio"."project" ADD COLUMN "citation_style" text;

--- a/src/lib/server/db/schemas/projects.schema.ts
+++ b/src/lib/server/db/schemas/projects.schema.ts
@@ -35,6 +35,7 @@ export const project = scholioSchema.table(
 		agentSystemPrompt: text('agent_system_prompt'),
 		// Optional org link — when set, AI key is resolved from the org (not the user)
 		orgId: text('org_id'),
+		citationStyle: text('citation_style'),
 		doi: text('doi'),
 		version: text('version'),
 		publishedAt: timestamp('published_at'),

--- a/src/lib/server/trpc/routers/projects.ts
+++ b/src/lib/server/trpc/routers/projects.ts
@@ -96,6 +96,7 @@ const updateProjectSchema = z.object({
   title: z.string().min(1).max(255).optional(),
   description: z.string().max(2000).nullable().optional(),
   status: z.enum(PROJECT_STATUSES).optional(),
+  citationStyle: z.enum(['apa', 'ieee', 'vancouver', 'chicago']).nullable().optional(),
   doi: z.string().max(255).nullable().optional(),
   version: z.string().max(50).nullable().optional(),
   publishedAt: z.coerce.date().nullable().optional()

--- a/src/routes/(app)/projects/[id]/+page.svelte
+++ b/src/routes/(app)/projects/[id]/+page.svelte
@@ -12,6 +12,7 @@
 	import { type DocumentType } from '$lib/domain/document';
 	import { onlineStore } from '$lib/stores/online.svelte';
 	import { canWriteDocument, type CollaboratorRole } from '$lib/domain/permissions';
+	import { type CitationStyle, CITATION_STYLE_LABELS } from '$lib/utils/citations';
 
 	let { data }: { data: PageData } = $props();
 
@@ -139,6 +140,11 @@
 			savingField = false;
 			editingField = null;
 		}
+	}
+
+	async function setProjectCitationStyle(style: CitationStyle | null) {
+		await trpc.projects.update.mutate({ id: data.project.id, citationStyle: style });
+		await invalidateAll();
 	}
 
 	let showCreateDoc = $state(false);
@@ -1538,6 +1544,25 @@
 								</button>
 							{/if}
 						</div>
+						<!-- Citation style -->
+						{#if data.isOwner}
+							{@const proj = data.project as typeof data.project & { citationStyle?: string | null }}
+							<div>
+								<span class="font-sans text-[11px] font-semibold tracking-wide text-ink-faint uppercase dark:text-dark-ink-faint">Citation style</span>
+								<div class="mt-1 flex flex-wrap gap-1.5">
+									{#each Object.entries(CITATION_STYLE_LABELS) as [s, label]}
+										<button
+											type="button"
+											onclick={() => setProjectCitationStyle(proj.citationStyle === s ? null : s as CitationStyle)}
+											class="rounded px-2 py-0.5 font-sans text-xs transition-colors {proj.citationStyle === s ? 'bg-accent text-white' : 'border border-paper-border text-ink-muted hover:border-accent/50 dark:border-dark-paper-border dark:text-dark-ink-muted'}"
+										>{label}</button>
+									{/each}
+								</div>
+								{#if proj.citationStyle}
+									<p class="mt-1 font-sans text-[10px] text-ink-faint dark:text-dark-ink-faint">Documents inherit this style unless overridden.</p>
+								{/if}
+							</div>
+						{/if}
 					</div>
 				</div>
 			{/if}

--- a/src/routes/(app)/projects/[id]/documents/[docId]/+page.server.ts
+++ b/src/routes/(app)/projects/[id]/documents/[docId]/+page.server.ts
@@ -95,10 +95,10 @@ export const load: PageServerLoad = async (event) => {
 			};
 		}),
 
-		// Project info (title + owner)
+		// Project info (title + owner + citationStyle)
 		event.locals.withRLS((db) =>
 			db
-				.select({ id: project.id, title: project.title, ownerId: project.ownerId, orgId: project.orgId })
+				.select({ id: project.id, title: project.title, ownerId: project.ownerId, orgId: project.orgId, citationStyle: project.citationStyle })
 				.from(project)
 				.where(eq(project.id, projectId))
 				.limit(1)
@@ -222,6 +222,7 @@ export const load: PageServerLoad = async (event) => {
 		projectTitle: proj?.title ?? '',
 		projectOwnerId: proj?.ownerId ?? '',
 		projectOrgId: proj?.orgId ?? null,
+		projectCitationStyle: (proj?.citationStyle ?? null) as 'apa' | 'ieee' | 'vancouver' | 'chicago' | null,
 		writerName,
 		collaborators,
 		inlineComments,

--- a/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
+++ b/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
@@ -339,15 +339,14 @@
 		showCitePicker = false;
 	}
 
-	// Persist citation style per document in localStorage
+	// Citation style: localStorage per-document overrides project default, which overrides 'apa'
 	$effect(() => {
 		if (!data.document) return;
 		const stored = localStorage.getItem(`cite-style-${data.document.id}`);
-		if (
-			stored &&
-			(stored === 'apa' || stored === 'ieee' || stored === 'vancouver' || stored === 'chicago')
-		) {
+		if (stored && (stored === 'apa' || stored === 'ieee' || stored === 'vancouver' || stored === 'chicago')) {
 			citationStyle = stored as CitationStyle;
+		} else if (data.projectCitationStyle) {
+			citationStyle = data.projectCitationStyle;
 		}
 	});
 


### PR DESCRIPTION
- citation_style column on project table (nullable)
- projects.update mutation accepts citationStyle
- document page inherits project citationStyle as fallback before 'apa'
- project page UI: toggle buttons in Publication section (owner only)