### PR TITLE
fix sample project creation when references already exist for the user

### DIFF
--- a/src/lib/server/trpc/routers/projects.ts
+++ b/src/lib/server/trpc/routers/projects.ts
@@ -621,7 +621,7 @@ export const projectsRouter = router({
           if (seenCiteKeys.has(ref.citeKey)) continue;
           seenCiteKeys.add(ref.citeKey);
           const refId = crypto.randomUUID();
-          await db
+          const inserted = await db
             .insert(reference)
             .values({
               id: refId,
@@ -639,11 +639,24 @@ export const projectsRouter = router({
               address: ref.address,
               isbn: ref.isbn
             })
-            .onConflictDoNothing();
-          await db
-            .insert(projectReference)
-            .values({ referenceId: refId, projectId })
-            .onConflictDoNothing();
+            .onConflictDoNothing()
+            .returning({ id: reference.id });
+
+          // If the reference already existed (conflict), fetch its real id
+          const actualRefId = inserted[0]?.id ?? (
+            await db
+              .select({ id: reference.id })
+              .from(reference)
+              .where(and(eq(reference.userId, userId), eq(reference.citeKey, ref.citeKey)))
+              .limit(1)
+          )[0]?.id;
+
+          if (actualRefId) {
+            await db
+              .insert(projectReference)
+              .values({ referenceId: actualRefId, projectId })
+              .onConflictDoNothing();
+          }
         }
       }
 


### PR DESCRIPTION
onConflictDoNothing on reference insert silently skips but leaves refId pointing to a non-existent row. Fall back to selecting the real id by (userId, citeKey) before inserting into project_reference.