### PR TITLE
feat(i18n): add translate="no" to all user-generated content

### DIFF
--- a/src/lib/components/bib/BibReferenceList.svelte
+++ b/src/lib/components/bib/BibReferenceList.svelte
@@ -225,10 +225,16 @@
 
 				<!-- Content -->
 				<div class="min-w-0 flex-1">
-					<p class="truncate font-sans text-sm font-medium text-ink dark:text-dark-ink">
+					<p
+						translate="no"
+						class="truncate font-sans text-sm font-medium text-ink dark:text-dark-ink"
+					>
 						{ref.title}
 					</p>
-					<p class="mt-0.5 font-sans text-xs text-ink-muted dark:text-dark-ink-muted">
+					<p
+						translate="no"
+						class="mt-0.5 font-sans text-xs text-ink-muted dark:text-dark-ink-muted"
+					>
 						{formatAuthors(ref)}{ref.year ? ' · ' + ref.year : ''}
 						{#if ref.journal}
 							· <em>{ref.journal}</em>
@@ -250,6 +256,7 @@
 					{/if}
 					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 					<p
+						translate="no"
 						class="mt-1.5 font-sans text-[11px] leading-snug text-ink-faint dark:text-dark-ink-faint"
 					>
 						{@html renderInlineMarkdown(
@@ -304,6 +311,7 @@
 												</span>
 												{#if sn.notes}
 													<span
+														translate="no"
 														class="flex-1 font-sans text-[11px] leading-snug text-ink dark:text-dark-ink"
 														>{sn.notes}</span
 													>

--- a/src/lib/components/documents/DocumentItem.svelte
+++ b/src/lib/components/documents/DocumentItem.svelte
@@ -37,7 +37,7 @@
 	<svg width="13" height="13" viewBox="0 0 13 13" fill="none" class="shrink-0 opacity-60">
 		<path d={typeIcon[type]} stroke="currentColor" stroke-width="1.2" stroke-linecap="round" />
 	</svg>
-	<span class="flex-1 truncate">{title}</span>
+	<span translate="no" class="flex-1 truncate">{title}</span>
 	{#if badge}
 		<span
 			class="ml-2 shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:bg-amber-900/30 dark:text-amber-300"

--- a/src/lib/components/editor/AnnotationsPanel.svelte
+++ b/src/lib/components/editor/AnnotationsPanel.svelte
@@ -185,6 +185,7 @@
 
 					{#if s.anchorText}
 						<blockquote
+							translate="no"
 							class="mb-2 border-l-2 border-accent bg-accent/5 px-2.5 py-1.5 font-serif text-xs leading-relaxed text-ink-muted italic dark:text-dark-ink-muted"
 						>
 							"{s.anchorText}"
@@ -216,6 +217,7 @@
 						</div>
 					{:else if s.notes}
 						<p
+							translate="no"
 							class="font-sans text-xs leading-relaxed whitespace-pre-wrap text-ink dark:text-dark-ink"
 						>
 							{s.notes}

--- a/src/lib/components/editor/CommentThread.svelte
+++ b/src/lib/components/editor/CommentThread.svelte
@@ -135,6 +135,7 @@
 	<!-- Anchor text excerpt / paragraph badge -->
 	{#if comment.anchorText}
 		<p
+			translate="no"
 			class="mb-2 truncate border-l-2 border-amber-400 pl-2 font-sans text-xs text-ink-muted italic dark:text-dark-ink-muted"
 		>
 			{comment.anchorText.slice(0, 80)}{comment.anchorText.length > 80 ? '…' : ''}
@@ -148,11 +149,11 @@
 	<!-- Main comment body -->
 	<div class="flex items-start justify-between gap-2">
 		<div class="min-w-0">
-			<p class="font-sans text-xs font-semibold text-ink dark:text-dark-ink">
+			<p translate="no" class="font-sans text-xs font-semibold text-ink dark:text-dark-ink">
 				{comment.authorName}
 			</p>
 			<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-			<div class="comment-body mt-0.5 font-sans text-sm text-ink dark:text-dark-ink">
+			<div translate="no" class="comment-body mt-0.5 font-sans text-sm text-ink dark:text-dark-ink">
 				{@html renderMd(comment.content)}
 			</div>
 			<p class="mt-1 font-sans text-xs text-ink-faint dark:text-dark-ink-faint">
@@ -204,11 +205,14 @@
 		<div class="mt-3 space-y-2 border-t border-paper-border pt-2 dark:border-dark-paper-border">
 			{#each comment.replies as reply (reply.id)}
 				<div>
-					<p class="font-sans text-xs font-semibold text-ink dark:text-dark-ink">
+					<p translate="no" class="font-sans text-xs font-semibold text-ink dark:text-dark-ink">
 						{reply.authorName}
 					</p>
 					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-					<div class="comment-body mt-0.5 font-sans text-sm text-ink dark:text-dark-ink">
+					<div
+						translate="no"
+						class="comment-body mt-0.5 font-sans text-sm text-ink dark:text-dark-ink"
+					>
 						{@html renderMd(reply.content)}
 					</div>
 					<p class="mt-0.5 font-sans text-xs text-ink-faint dark:text-dark-ink-faint">

--- a/src/lib/components/editor/MarkdownPreview.svelte
+++ b/src/lib/components/editor/MarkdownPreview.svelte
@@ -430,6 +430,7 @@
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div
 		bind:this={container}
+		translate="no"
 		class="prose-serif prose max-w-none dark:prose-invert"
 		style="overflow: visible;"
 		onmouseup={handleMouseUp}

--- a/src/lib/components/layout/MobileHeader.svelte
+++ b/src/lib/components/layout/MobileHeader.svelte
@@ -72,7 +72,9 @@
 				class="absolute top-full right-0 z-50 mt-1.5 w-44 rounded-xl border border-paper-border bg-paper shadow-lg dark:border-dark-paper-border dark:bg-dark-paper"
 			>
 				<div class="border-b border-paper-border px-4 py-2.5 dark:border-dark-paper-border">
-					<p class="font-sans text-sm font-medium text-ink dark:text-dark-ink">{user.name}</p>
+					<p translate="no" class="font-sans text-sm font-medium text-ink dark:text-dark-ink">
+						{user.name}
+					</p>
 					<p class="font-sans text-xs text-ink-faint dark:text-dark-ink-faint">{user.email}</p>
 				</div>
 				<ul class="py-1">

--- a/src/lib/components/layout/Navbar.svelte
+++ b/src/lib/components/layout/Navbar.svelte
@@ -295,7 +295,9 @@
 					{initials}
 				</a>
 				<div class="hidden sm:block">
-					<p class="font-sans text-sm font-medium text-ink dark:text-dark-ink">{user.name}</p>
+					<p translate="no" class="font-sans text-sm font-medium text-ink dark:text-dark-ink">
+						{user.name}
+					</p>
 					<p class="font-sans text-xs text-ink-faint dark:text-dark-ink-faint">{user.email}</p>
 				</div>
 			</div>

--- a/src/lib/components/layout/QuickNoteButton.svelte
+++ b/src/lib/components/layout/QuickNoteButton.svelte
@@ -121,7 +121,7 @@
 								disabled={creating}
 								class="w-full px-4 py-2 text-left font-sans text-sm text-ink transition-colors hover:bg-paper-ui disabled:opacity-50 dark:text-dark-ink dark:hover:bg-dark-paper-ui"
 							>
-								{p.title}
+								<span translate="no">{p.title}</span>
 							</button>
 						</li>
 					{/each}

--- a/src/lib/components/projects/ProjectCard.svelte
+++ b/src/lib/components/projects/ProjectCard.svelte
@@ -80,6 +80,7 @@
 		<div class="flex items-start justify-between gap-3">
 			<div class="flex min-w-0 items-center gap-2">
 				<h3
+					translate="no"
 					class="font-serif text-lg font-semibold text-ink group-hover:text-accent dark:text-dark-ink dark:group-hover:text-accent"
 				>
 					{title}
@@ -131,6 +132,7 @@
 
 		{#if description}
 			<p
+				translate="no"
 				class="mt-2 line-clamp-2 font-sans text-sm leading-relaxed text-ink-muted dark:text-dark-ink-muted"
 			>
 				{description}

--- a/src/lib/components/projects/ProjectSidebar.svelte
+++ b/src/lib/components/projects/ProjectSidebar.svelte
@@ -703,12 +703,14 @@
 											</span>
 											<div class="min-w-0">
 												<p
+													translate="no"
 													class="truncate font-sans text-xs font-medium text-ink dark:text-dark-ink"
 												>
 													{u.displayName ?? u.name}
 												</p>
 												{#if u.institution}
 													<p
+														translate="no"
 														class="truncate font-sans text-[11px] text-ink-faint dark:text-dark-ink-faint"
 													>
 														{u.institution}

--- a/src/lib/components/projects/TagManager.svelte
+++ b/src/lib/components/projects/TagManager.svelte
@@ -74,7 +74,7 @@
 				<span
 					class="flex items-center gap-1 rounded-full bg-accent/10 px-2.5 py-0.5 font-sans text-xs font-medium text-accent dark:bg-accent/20"
 				>
-					{t.name}
+					<span translate="no">{t.name}</span>
 					<button
 						onclick={() => removeTag(t.id)}
 						class="ml-0.5 rounded-full text-accent/60 hover:text-accent"
@@ -110,7 +110,7 @@
 						type="button"
 						onclick={() => addTag(t)}
 						class="flex w-full items-center px-3 py-1.5 font-sans text-xs text-ink hover:bg-paper-ui dark:text-dark-ink dark:hover:bg-dark-paper-ui"
-						>{t.name}</button
+						><span translate="no">{t.name}</span></button
 					>
 				{/each}
 				{#if inputValue.trim() && !filtered.some((t) => t.name.toLowerCase() === inputValue.toLowerCase())}

--- a/src/routes/(app)/explore/+page.svelte
+++ b/src/routes/(app)/explore/+page.svelte
@@ -166,11 +166,17 @@
 						>
 							<div class="flex items-start justify-between gap-4">
 								<div class="min-w-0 flex-1">
-									<h2 class="font-serif text-base font-semibold text-ink dark:text-dark-ink">
+									<h2
+										translate="no"
+										class="font-serif text-base font-semibold text-ink dark:text-dark-ink"
+									>
 										{proj.title}
 									</h2>
 									{#if proj.description}
-										<p class="mt-1 font-sans text-sm text-ink-muted dark:text-dark-ink-muted">
+										<p
+											translate="no"
+											class="mt-1 font-sans text-sm text-ink-muted dark:text-dark-ink-muted"
+										>
 											{proj.description}
 										</p>
 									{/if}
@@ -182,7 +188,10 @@
 											>
 												Abstract
 											</p>
-											<p class="line-clamp-4 font-sans text-sm text-ink dark:text-dark-ink">
+											<p
+												translate="no"
+												class="line-clamp-4 font-sans text-sm text-ink dark:text-dark-ink"
+											>
 												{proj.abstractContent}
 											</p>
 										</div>
@@ -197,7 +206,10 @@
 										>
 											{(proj.ownerDisplayName ?? proj.ownerName ?? '?').charAt(0).toUpperCase()}
 										</span>
-										<span class="font-sans text-xs text-ink-muted dark:text-dark-ink-muted">
+										<span
+											translate="no"
+											class="font-sans text-xs text-ink-muted dark:text-dark-ink-muted"
+										>
 											{proj.ownerDisplayName ?? proj.ownerName}
 											{#if proj.ownerInstitution}
 												· {proj.ownerInstitution}
@@ -248,16 +260,23 @@
 									{(r.display_name ?? r.name ?? '?').charAt(0).toUpperCase()}
 								</span>
 								<div class="min-w-0 flex-1">
-									<p class="font-sans text-sm font-semibold text-ink dark:text-dark-ink">
+									<p
+										translate="no"
+										class="font-sans text-sm font-semibold text-ink dark:text-dark-ink"
+									>
 										{r.display_name ?? r.name}
 									</p>
 									{#if r.institution}
-										<p class="font-sans text-xs text-ink-muted dark:text-dark-ink-muted">
+										<p
+											translate="no"
+											class="font-sans text-xs text-ink-muted dark:text-dark-ink-muted"
+										>
 											{r.institution}
 										</p>
 									{/if}
 									{#if r.bio}
 										<p
+											translate="no"
 											class="mt-1 line-clamp-2 font-sans text-xs text-ink-muted dark:text-dark-ink-muted"
 										>
 											{r.bio}

--- a/src/routes/(app)/projects/[id]/ai/+page.svelte
+++ b/src/routes/(app)/projects/[id]/ai/+page.svelte
@@ -382,6 +382,7 @@
 									<!-- Bubble + pending actions for this message -->
 									<div class="flex max-w-[80%] flex-col">
 										<div
+											translate="no"
 											class="rounded-2xl px-4 py-3 font-sans text-sm leading-relaxed {msg.role ===
 											'user'
 												? 'rounded-tr-sm bg-accent text-white'
@@ -401,6 +402,7 @@
 												>
 												{#each msg.docsUsed as doc (doc.id)}
 													<a
+														translate="no"
 														href="/projects/{data.project.id}/documents/{doc.id}"
 														class="font-sans text-[11px] text-ink-muted underline-offset-2 hover:text-ink hover:underline dark:text-dark-ink-muted dark:hover:text-dark-ink"
 														>{doc.title}</a

--- a/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
+++ b/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
@@ -1188,7 +1188,9 @@
 						{data.projectTitle}
 					</button>
 					<span class="text-ink-faint dark:text-dark-ink-faint">/</span>
-					<span class="truncate font-sans text-sm font-medium text-ink dark:text-dark-ink"
+					<span
+						translate="no"
+						class="truncate font-sans text-sm font-medium text-ink dark:text-dark-ink"
 						>{data.document.title}</span
 					>
 				</div>
@@ -1221,7 +1223,9 @@
 					{data.projectTitle}
 				</button>
 				<span class="text-ink-faint dark:text-dark-ink-faint">/</span>
-				<span class="truncate font-medium text-ink dark:text-dark-ink">{docTitle}</span>
+				<span translate="no" class="truncate font-medium text-ink dark:text-dark-ink"
+					>{docTitle}</span
+				>
 
 				<!-- Writer badge -->
 				{#if currentWriterUserId !== null}

--- a/src/routes/(app)/projects/[id]/documents/[docId]/history/+page.svelte
+++ b/src/routes/(app)/projects/[id]/documents/[docId]/history/+page.svelte
@@ -167,7 +167,7 @@
 			>
 				<path d="M15 18l-6-6 6-6" />
 			</svg>
-			{data.document.title}
+			<span translate="no">{data.document.title}</span>
 		</a>
 		<span class="text-ink-faint dark:text-dark-ink-faint">/</span>
 		<span class="font-sans text-sm font-medium text-ink dark:text-dark-ink">Historial</span>

--- a/src/routes/(app)/projects/[id]/documents/[docId]/read/+page.svelte
+++ b/src/routes/(app)/projects/[id]/documents/[docId]/read/+page.svelte
@@ -90,7 +90,9 @@
 			Edit
 		</a>
 		<span class="text-ink-faint dark:text-dark-ink-faint">/</span>
-		<span class="font-serif font-semibold text-ink dark:text-dark-ink">{data.book.title}</span>
+		<span translate="no" class="font-serif font-semibold text-ink dark:text-dark-ink"
+			>{data.book.title}</span
+		>
 		{#if data.chapters.length > 0}
 			<span class="font-sans text-xs text-ink-faint dark:text-dark-ink-faint">
 				{data.chapters.length} chapter{data.chapters.length === 1 ? '' : 's'}
@@ -148,7 +150,7 @@
 								: 'text-ink-muted hover:text-ink dark:text-dark-ink-muted dark:hover:text-dark-ink'}"
 						>
 							<span class="mr-1.5 text-xs text-ink-faint dark:text-dark-ink-faint">{i + 1}.</span>
-							{chapter.title}
+							<span translate="no">{chapter.title}</span>
 						</button>
 					{/each}
 				</nav>
@@ -159,7 +161,7 @@
 		<main class="flex-1 overflow-y-auto">
 			<div class="mx-auto max-w-2xl px-6 py-10">
 				<!-- Book title -->
-				<h1 class="mb-8 font-serif text-3xl font-bold text-ink dark:text-dark-ink">
+				<h1 translate="no" class="mb-8 font-serif text-3xl font-bold text-ink dark:text-dark-ink">
 					{data.book.title}
 				</h1>
 
@@ -190,7 +192,10 @@
 								>
 									Chapter {i + 1}
 								</p>
-								<h2 class="font-serif text-2xl font-semibold text-ink dark:text-dark-ink">
+								<h2
+									translate="no"
+									class="font-serif text-2xl font-semibold text-ink dark:text-dark-ink"
+								>
 									{chapter.title}
 								</h2>
 							</div>

--- a/src/routes/(app)/projects/[id]/issues/+page.svelte
+++ b/src/routes/(app)/projects/[id]/issues/+page.svelte
@@ -198,7 +198,10 @@
 
 						<!-- Title + meta -->
 						<div class="min-w-0 flex-1">
-							<p class="truncate font-sans text-sm font-medium text-zinc-900 dark:text-zinc-100">
+							<p
+								translate="no"
+								class="truncate font-sans text-sm font-medium text-zinc-900 dark:text-zinc-100"
+							>
 								{iss.title}
 							</p>
 							<p class="mt-0.5 font-sans text-xs text-zinc-400 dark:text-zinc-500">

--- a/src/routes/(app)/projects/[id]/issues/[issueId]/+page.svelte
+++ b/src/routes/(app)/projects/[id]/issues/[issueId]/+page.svelte
@@ -276,7 +276,10 @@
 			/>
 		{:else}
 			<div class="flex items-start gap-2">
-				<h1 class="flex-1 font-sans text-2xl font-semibold text-zinc-900 dark:text-zinc-100">
+				<h1
+					translate="no"
+					class="flex-1 font-sans text-2xl font-semibold text-zinc-900 dark:text-zinc-100"
+				>
 					{savedTitle}
 				</h1>
 				{#if data.canEdit}

--- a/src/routes/(app)/projects/[id]/review/+page.svelte
+++ b/src/routes/(app)/projects/[id]/review/+page.svelte
@@ -132,6 +132,7 @@
 								{#if thread.anchorContext && thread.anchorText}
 									<!-- Selection comment: paragraph with highlight -->
 									<p
+										translate="no"
 										class="mb-2 rounded-md border-l-2 border-amber-300 bg-paper-ui px-2.5 py-1.5 font-sans text-xs leading-relaxed text-ink dark:border-amber-600 dark:bg-dark-paper-ui dark:text-dark-ink"
 									>
 										<!-- eslint-disable-next-line svelte/no-at-html-tags -->
@@ -140,6 +141,7 @@
 								{:else if thread.anchorContext && thread.paragraphNumber}
 									<!-- Paragraph comment: show the paragraph text -->
 									<p
+										translate="no"
 										class="mb-2 rounded-md border-l-2 border-paper-border bg-paper-ui px-2.5 py-1.5 font-sans text-xs leading-relaxed text-ink-muted dark:border-dark-paper-border dark:bg-dark-paper-ui dark:text-dark-ink-muted"
 									>
 										¶{thread.paragraphNumber} · {thread.anchorContext}
@@ -147,6 +149,7 @@
 								{:else if thread.anchorText}
 									<!-- Fallback: plain quoted selection (no context stored) -->
 									<p
+										translate="no"
 										class="mb-2 rounded-md border-l-2 border-amber-300 bg-paper-ui px-2.5 py-1.5 font-sans text-xs text-ink-muted italic dark:border-amber-600 dark:bg-dark-paper-ui dark:text-dark-ink-muted"
 									>
 										"{thread.anchorText}"

--- a/src/routes/(app)/projects/[id]/search/+page.svelte
+++ b/src/routes/(app)/projects/[id]/search/+page.svelte
@@ -76,10 +76,14 @@
 						href="/projects/{data.projectId}/documents/{result.document_id}"
 						class="block rounded-xl border border-paper-border bg-paper p-4 transition-colors hover:border-accent/40 hover:bg-paper-ui dark:border-dark-paper-border dark:bg-dark-paper dark:hover:border-accent/40 dark:hover:bg-dark-paper-ui"
 					>
-						<p class="mb-1.5 font-sans text-sm font-medium text-ink dark:text-dark-ink">
+						<p
+							translate="no"
+							class="mb-1.5 font-sans text-sm font-medium text-ink dark:text-dark-ink"
+						>
 							{result.title}
 						</p>
 						<p
+							translate="no"
 							class="line-clamp-3 font-sans text-xs leading-relaxed text-ink-muted dark:text-dark-ink-muted"
 						>
 							{result.text}

--- a/src/routes/(app)/tags/+page.svelte
+++ b/src/routes/(app)/tags/+page.svelte
@@ -125,7 +125,7 @@
 							onclick={() => startEdit(tag)}
 							class="flex-1 text-left font-sans text-sm text-ink hover:text-accent dark:text-dark-ink dark:hover:text-accent"
 						>
-							{tag.name}
+							<span translate="no">{tag.name}</span>
 						</button>
 						<span class="shrink-0 font-sans text-xs text-ink-faint dark:text-dark-ink-faint">
 							{tag.projectCount === 1 ? '1 project' : `${tag.projectCount} projects`}

--- a/src/routes/(scipy)/project/[id]/templates/+page.svelte
+++ b/src/routes/(scipy)/project/[id]/templates/+page.svelte
@@ -270,7 +270,9 @@
 					>
 						<div>
 							<div class="flex items-center gap-2">
-								<span class="font-medium text-ink dark:text-dark-ink">{template.name}</span>
+								<span translate="no" class="font-medium text-ink dark:text-dark-ink"
+									>{template.name}</span
+								>
 								<span class="font-mono text-xs text-ink-faint dark:text-dark-ink-faint"
 									>{template.type}</span
 								>
@@ -283,7 +285,7 @@
 								{/if}
 							</div>
 							{#if template.description}
-								<p class="mt-1 text-sm text-ink-faint dark:text-dark-ink-faint">
+								<p translate="no" class="mt-1 text-sm text-ink-faint dark:text-dark-ink-faint">
 									{template.description}
 								</p>
 							{/if}

--- a/src/routes/invitations/[token]/+page.svelte
+++ b/src/routes/invitations/[token]/+page.svelte
@@ -134,11 +134,17 @@
 				>
 					Collaboration invitation
 				</div>
-				<h1 class="mt-2 font-serif text-2xl font-semibold text-ink dark:text-dark-ink">
+				<h1
+					translate="no"
+					class="mt-2 font-serif text-2xl font-semibold text-ink dark:text-dark-ink"
+				>
 					{data.invitation.projectTitle ?? 'Untitled project'}
 				</h1>
 				{#if data.invitation.projectDescription}
-					<p class="mt-2 font-sans text-sm leading-relaxed text-ink-muted dark:text-dark-ink-muted">
+					<p
+						translate="no"
+						class="mt-2 font-sans text-sm leading-relaxed text-ink-muted dark:text-dark-ink-muted"
+					>
 						{data.invitation.projectDescription}
 					</p>
 				{/if}

--- a/src/routes/org-invitations/[token]/+page.svelte
+++ b/src/routes/org-invitations/[token]/+page.svelte
@@ -73,7 +73,7 @@
 						</svg>
 					</div>
 					<h1 class="font-serif text-2xl font-semibold text-ink dark:text-dark-ink">
-						Welcome to {data.invitation.orgName ?? 'the organization'}!
+						Welcome to <span translate="no">{data.invitation.orgName ?? 'the organization'}</span>!
 					</h1>
 					<p class="mt-2 font-sans text-sm text-ink-muted dark:text-dark-ink-muted">
 						Redirecting to your projects...
@@ -85,7 +85,9 @@
 						Already a member
 					</h1>
 					<p class="mt-2 font-sans text-sm text-ink-muted dark:text-dark-ink-muted">
-						You are already a member of {data.invitation.orgName ?? 'this organization'}.
+						You are already a member of <span translate="no"
+							>{data.invitation.orgName ?? 'this organization'}</span
+						>.
 					</p>
 					<button
 						onclick={() => navigate('/projects')}
@@ -130,7 +132,10 @@
 				>
 					Organization invitation
 				</div>
-				<h1 class="mt-2 font-serif text-2xl font-semibold text-ink dark:text-dark-ink">
+				<h1
+					translate="no"
+					class="mt-2 font-serif text-2xl font-semibold text-ink dark:text-dark-ink"
+				>
 					{data.invitation.orgName ?? 'Organization'}
 				</h1>
 				{#if data.invitation.orgSlug}

--- a/src/routes/preview/[token]/+page.svelte
+++ b/src/routes/preview/[token]/+page.svelte
@@ -51,6 +51,7 @@
 			<span class="hidden h-4 w-px bg-paper-border sm:block dark:bg-dark-paper-border"></span>
 			<span class="hidden items-center gap-1.5 sm:flex">
 				<span
+					translate="no"
 					class="max-w-[180px] truncate font-sans text-sm text-ink-muted dark:text-dark-ink-muted"
 				>
 					{data.document.title}
@@ -85,7 +86,7 @@
 <main class="mx-auto max-w-2xl px-6 py-12">
 	<!-- Document header -->
 	<div class="mb-8 border-b border-paper-border pb-6 dark:border-dark-paper-border">
-		<h1 class="font-serif text-3xl font-semibold text-ink dark:text-dark-ink">
+		<h1 translate="no" class="font-serif text-3xl font-semibold text-ink dark:text-dark-ink">
 			{data.document.title}
 		</h1>
 		{#if data.version.changeDescription}


### PR DESCRIPTION
Marks UGC elements across 25 files so browser auto-translation (Chrome, Firefox, Safari) leaves user-written text untouched while still translating the app's own UI labels and navigation.