### PR TITLE
fix(search): use block-element textContent for scroll-to-chunk

### DIFF
--- a/src/lib/components/documents/DocSearchOverlay.svelte
+++ b/src/lib/components/documents/DocSearchOverlay.svelte
@@ -38,14 +38,21 @@
 	}
 
 	function scrollToChunk(text: string) {
-		const needle = text.slice(0, 60).trim().toLowerCase();
-		const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
-		let node: Text | null;
-		while ((node = walker.nextNode() as Text | null)) {
-			const content = node.textContent?.toLowerCase() ?? '';
-			if (content.includes(needle.slice(0, 40))) {
-				node.parentElement?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-				return;
+		const needle = text.trim().toLowerCase();
+		// Scope to the rendered prose container to avoid false matches in toolbar/sidebar.
+		// Falls back to body (e.g. editor-only mode where .prose isn't present).
+		const root = document.querySelector('.prose') ?? document.body;
+		const blocks = root.querySelectorAll('p, h1, h2, h3, h4, h5, h6, li, blockquote, td');
+		// Try progressively shorter prefixes — text nodes can be split by inline elements
+		// so we need textContent on block elements which concatenates all descendants.
+		for (const len of [50, 30, 15]) {
+			const prefix = needle.slice(0, len);
+			if (!prefix) continue;
+			for (const block of blocks) {
+				if ((block.textContent?.toLowerCase() ?? '').includes(prefix)) {
+					block.scrollIntoView({ behavior: 'smooth', block: 'center' });
+					return;
+				}
 			}
 		}
 	}

--- a/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
+++ b/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
@@ -549,6 +549,17 @@
 	let sourceReference = $derived(data.sourceReference);
 	let showTitleRefPicker = $state(false);
 	let titlePickerRefId = $state('');
+	let titlePickerSearch = $state('');
+	const filteredTitleRefs = $derived.by(() => {
+		const q = titlePickerSearch.toLowerCase().trim();
+		if (!q) return projectRefs;
+		return projectRefs.filter(
+			(r) =>
+				r.citeKey.toLowerCase().includes(q) ||
+				r.title.toLowerCase().includes(q) ||
+				r.authors.some((a) => `${a.last} ${a.first ?? ''}`.toLowerCase().includes(q))
+		);
+	});
 
 	const sourceRefFull = $derived.by(() => {
 		const sr = sourceReference;
@@ -580,6 +591,7 @@
 		await loadDocSubnotes();
 		showTitleRefPicker = false;
 		titlePickerRefId = '';
+		titlePickerSearch = '';
 	}
 
 	async function handleTitleRefUnlink() {
@@ -1972,6 +1984,7 @@
 								onclick={() => {
 									loadRefs();
 									titlePickerRefId = sourceReference?.id ?? '';
+									titlePickerSearch = sourceReference?.citeKey ?? '';
 									showTitleRefPicker = true;
 								}}
 								class="rounded p-1 text-ink-faint transition-colors hover:text-ink dark:text-dark-ink-faint dark:hover:text-dark-ink"
@@ -2028,6 +2041,7 @@
 						onclick={() => {
 							loadRefs();
 							titlePickerRefId = '';
+							titlePickerSearch = '';
 							showTitleRefPicker = true;
 						}}
 						class="mb-1 flex items-center gap-1.5 rounded border border-dashed border-paper-border px-3 py-1.5 font-sans text-xs text-ink-faint transition-colors hover:border-accent hover:text-accent dark:border-dark-paper-border dark:text-dark-ink-faint dark:hover:border-accent dark:hover:text-accent"
@@ -2050,36 +2064,93 @@
 					</button>
 				{/if}
 				{#if showTitleRefPicker}
-					<div
-						class="mb-3 flex items-center gap-2 rounded border border-paper-border bg-paper-ui px-3 py-2 dark:border-dark-paper-border dark:bg-dark-paper-ui"
-					>
-						<select
-							bind:value={titlePickerRefId}
-							class="min-w-0 flex-1 rounded border border-paper-border bg-paper px-2 py-1 font-sans text-xs text-ink focus:border-accent focus:outline-none dark:border-dark-paper-border dark:bg-dark-paper dark:text-dark-ink"
+					<div class="relative mb-3">
+						<div
+							class="flex items-center gap-2 rounded border border-accent bg-paper-ui px-3 py-2 dark:bg-dark-paper-ui"
 						>
-							<option value="">— elige referencia —</option>
-							{#each projectRefs as ref (ref.id ?? ref.citeKey)}
-								<option value={ref.id ?? ''}>{ref.citeKey}</option>
-							{/each}
-						</select>
-						<button
-							type="button"
-							onclick={handleTitleRefAssign}
-							disabled={!titlePickerRefId}
-							class="shrink-0 rounded bg-accent px-2.5 py-1 font-sans text-xs font-medium text-white hover:bg-accent/90 disabled:opacity-50"
-						>
-							Asignar
-						</button>
-						<button
-							type="button"
-							onclick={() => {
-								showTitleRefPicker = false;
-								titlePickerRefId = '';
-							}}
-							class="shrink-0 font-sans text-xs text-ink-faint hover:text-ink dark:text-dark-ink-faint dark:hover:text-dark-ink"
-						>
-							Cancelar
-						</button>
+							<input
+								{@attach (node) => node.focus()}
+								type="text"
+								bind:value={titlePickerSearch}
+								placeholder="Buscar por citeKey, título o autor…"
+								class="min-w-0 flex-1 bg-transparent font-sans text-xs text-ink placeholder:text-ink-faint focus:outline-none dark:text-dark-ink dark:placeholder:text-dark-ink-faint"
+								onkeydown={(e) => {
+									if (e.key === 'Escape') {
+										showTitleRefPicker = false;
+										titlePickerSearch = '';
+										titlePickerRefId = '';
+									} else if (e.key === 'Enter') {
+										const first = filteredTitleRefs[0];
+										if (first?.id) {
+											titlePickerRefId = first.id;
+											handleTitleRefAssign();
+										}
+									}
+								}}
+							/>
+							<button
+								type="button"
+								onclick={() => {
+									showTitleRefPicker = false;
+									titlePickerSearch = '';
+									titlePickerRefId = '';
+								}}
+								aria-label="Cancelar"
+								class="shrink-0 text-ink-faint transition-colors hover:text-ink dark:text-dark-ink-faint dark:hover:text-dark-ink"
+							>
+								<svg
+									width="12"
+									height="12"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									aria-hidden="true"
+								>
+									<line x1="18" y1="6" x2="6" y2="18" />
+									<line x1="6" y1="6" x2="18" y2="18" />
+								</svg>
+							</button>
+						</div>
+						{#if filteredTitleRefs.length > 0}
+							<ul
+								class="absolute top-full right-0 left-0 z-20 max-h-56 overflow-y-auto rounded-b border border-t-0 border-paper-border bg-paper shadow-lg dark:border-dark-paper-border dark:bg-dark-paper"
+							>
+								{#each filteredTitleRefs as ref (ref.id ?? ref.citeKey)}
+									<li>
+										<button
+											type="button"
+											onclick={() => {
+												titlePickerRefId = ref.id ?? '';
+												handleTitleRefAssign();
+											}}
+											class="flex w-full items-baseline gap-2 px-3 py-2 text-left hover:bg-paper-ui dark:hover:bg-dark-paper-ui"
+										>
+											<span class="shrink-0 font-mono text-[11px] font-medium text-accent"
+												>@{ref.citeKey}</span
+											>
+											<span class="min-w-0 truncate font-sans text-xs text-ink dark:text-dark-ink"
+												>{ref.title}</span
+											>
+											{#if ref.year}
+												<span
+													class="shrink-0 font-sans text-[11px] text-ink-faint dark:text-dark-ink-faint"
+													>{ref.year}</span
+												>
+											{/if}
+										</button>
+									</li>
+								{/each}
+							</ul>
+						{:else if titlePickerSearch.trim()}
+							<div
+								class="absolute top-full right-0 left-0 z-20 rounded-b border border-t-0 border-paper-border bg-paper px-3 py-2 font-sans text-xs text-ink-faint shadow-lg dark:border-dark-paper-border dark:bg-dark-paper dark:text-dark-ink-faint"
+							>
+								Sin resultados
+							</div>
+						{/if}
 					</div>
 				{/if}
 				{#if editingTitle}

--- a/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
+++ b/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
@@ -1839,7 +1839,7 @@
 				<!-- Semantic search button -->
 				<button
 					onclick={() => (showDocSearch = !showDocSearch)}
-					title="Buscar en el documento (Ctrl+F)"
+					title="Search in document (Ctrl+F)"
 					aria-pressed={showDocSearch}
 					class="flex items-center justify-center rounded-md border px-2.5 py-1.5 transition-colors {showDocSearch
 						? 'border-accent bg-accent/10 text-accent dark:bg-accent/20'
@@ -1980,7 +1980,7 @@
 						<div class="flex shrink-0 items-center gap-0.5">
 							<button
 								type="button"
-								title="Cambiar referencia"
+								title="Change reference"
 								onclick={() => {
 									loadRefs();
 									titlePickerRefId = sourceReference?.id ?? '';
@@ -2006,7 +2006,7 @@
 							</button>
 							<button
 								type="button"
-								title="Desenlazar referencia"
+								title="Unlink reference"
 								onclick={handleTitleRefUnlink}
 								class="rounded p-1 text-ink-faint transition-colors hover:text-red-500 dark:text-dark-ink-faint dark:hover:text-red-400"
 							>
@@ -2060,7 +2060,7 @@
 							<path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71" />
 							<path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71" />
 						</svg>
-						Enlazar referencia bibliográfica
+						Link bibliographic reference
 					</button>
 				{/if}
 				{#if showTitleRefPicker}
@@ -2072,7 +2072,7 @@
 								{@attach (node) => node.focus()}
 								type="text"
 								bind:value={titlePickerSearch}
-								placeholder="Buscar por citeKey, título o autor…"
+								placeholder="Search by citeKey, title or author…"
 								class="min-w-0 flex-1 bg-transparent font-sans text-xs text-ink placeholder:text-ink-faint focus:outline-none dark:text-dark-ink dark:placeholder:text-dark-ink-faint"
 								onkeydown={(e) => {
 									if (e.key === 'Escape') {
@@ -2095,7 +2095,7 @@
 									titlePickerSearch = '';
 									titlePickerRefId = '';
 								}}
-								aria-label="Cancelar"
+								aria-label="Cancel"
 								class="shrink-0 text-ink-faint transition-colors hover:text-ink dark:text-dark-ink-faint dark:hover:text-dark-ink"
 							>
 								<svg
@@ -2148,7 +2148,7 @@
 							<div
 								class="absolute top-full right-0 left-0 z-20 rounded-b border border-t-0 border-paper-border bg-paper px-3 py-2 font-sans text-xs text-ink-faint shadow-lg dark:border-dark-paper-border dark:bg-dark-paper dark:text-dark-ink-faint"
 							>
-								Sin resultados
+								No results
 							</div>
 						{/if}
 					</div>


### PR DESCRIPTION
The previous TreeWalker approach matched against individual text nodes, which fail when text is split by inline elements (<em>, <mark>, etc.). Now queries block-level elements and uses textContent (which concatenates all descendants), scoped to .prose to avoid false matches in the UI shell.