### PR TITLE
refactor(embeddings): token-based chunking with overlap

### DIFF
--- a/src/lib/server/embeddings.ts
+++ b/src/lib/server/embeddings.ts
@@ -6,11 +6,51 @@ import { eq } from 'drizzle-orm';
 
 const EMBED_MODEL = 'text-embedding-3-small';
 
+const CHUNK_TOKENS = 512;
+const OVERLAP_TOKENS = 64;
+const CHARS_PER_TOKEN = 4;
+
+function estimateTokens(text: string): number {
+	return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
 function chunkText(text: string): string[] {
-	return text
+	const paragraphs = text
 		.split(/\n\n+/)
 		.map((s) => s.trim())
 		.filter((s) => s.length > 40);
+
+	const chunks: string[] = [];
+	let current: string[] = [];
+	let currentTokens = 0;
+
+	for (const para of paragraphs) {
+		const paraTokens = estimateTokens(para);
+
+		if (currentTokens + paraTokens > CHUNK_TOKENS && current.length > 0) {
+			chunks.push(current.join('\n\n'));
+
+			// carry over trailing paragraphs that fit within the overlap budget
+			const overlap: string[] = [];
+			let overlapTokens = 0;
+			for (let i = current.length - 1; i >= 0; i--) {
+				const t = estimateTokens(current[i]);
+				if (overlapTokens + t > OVERLAP_TOKENS) break;
+				overlap.unshift(current[i]);
+				overlapTokens += t;
+			}
+
+			current = [...overlap, para];
+			currentTokens = overlapTokens + paraTokens;
+		} else {
+			current.push(para);
+			currentTokens += paraTokens;
+		}
+	}
+
+	if (current.length > 0) chunks.push(current.join('\n\n'));
+
+	return chunks;
 }
 
 export async function embedQuery(text: string): Promise<number[]> {

--- a/src/lib/server/trpc/routers/ai.test.ts
+++ b/src/lib/server/trpc/routers/ai.test.ts
@@ -67,15 +67,13 @@ describe('indexDocument', () => {
 			vi.fn().mockResolvedValue({
 				ok: true,
 				json: async () => ({
-					data: [
-						{ embedding: fakeEmbedding(1), index: 0 },
-						{ embedding: fakeEmbedding(2), index: 1 },
-						{ embedding: fakeEmbedding(3), index: 2 }
-					]
+					data: [{ embedding: fakeEmbedding(1), index: 0 }]
 				})
 			})
 		);
 
+		// Three short paragraphs — well under the 512-token chunk limit, so they
+		// are combined into a single chunk by the token-based chunking strategy.
 		const content = [
 			'La metodología empleada sigue un enfoque cuantitativo basado en encuestas estructuradas.',
 			'Los resultados muestran una correlación significativa entre las variables analizadas (p < 0.05).',
@@ -98,7 +96,7 @@ describe('indexDocument', () => {
 			.from(documentChunk)
 			.where(eq(documentChunk.documentId, documentId));
 
-		expect(chunks.length).toBe(3);
+		expect(chunks.length).toBe(1);
 		expect(chunks[0].chunkIndex).toBe(0);
 		expect(chunks[0].text).toContain('metodología');
 		expect(chunks[0].embedding).toHaveLength(1536);


### PR DESCRIPTION
Replace paragraph-per-chunk strategy with a sliding window approach: accumulate paragraphs up to ~512 tokens per chunk, then carry over the last ~64 tokens as overlap into the next chunk to preserve context at boundaries.