### PR TITLE
fix(ai): retry on interrupted stream connections

### DIFF
--- a/src/lib/components/ai/AiEditorPanel.svelte
+++ b/src/lib/components/ai/AiEditorPanel.svelte
@@ -40,6 +40,7 @@
 		role: 'user' | 'assistant' | 'system';
 		content: string;
 		docsUsed?: { id: string; title: string }[];
+		broken?: boolean;
 	};
 
 	const CONV_KEY = untrack(() => `ai-editor-conv-${documentId}`);
@@ -78,6 +79,7 @@
 	let messages = $state<Message[]>([]);
 	let conversationId = $state<string | undefined>(undefined);
 	let input = $state('');
+	let retryText = $state<string | null>(null);
 	let loading = $state(false);
 	let loadingHint = $state('Thinking…');
 	let error = $state('');
@@ -137,12 +139,14 @@
 		input = prompt;
 	}
 
-	async function send() {
-		const text = input.trim();
+	async function send(overrideText?: string) {
+		const text = (overrideText ?? input).trim();
 		if (!text || loading) return;
 
+		retryText = null;
+		messages = messages.filter((m) => !m.broken);
 		messages = [...messages, { role: 'user', content: text }];
-		input = '';
+		if (!overrideText) input = '';
 		loading = true;
 		loadingHint = 'Thinking…';
 		error = '';
@@ -231,6 +235,9 @@
 							messages = [...messages, { role: 'system', content: msg }];
 							assistantIdx = -1;
 							await scrollToBottom();
+						} else if (assistantIdx !== -1) {
+							messages = messages.map((m, i) => (i === assistantIdx ? { ...m, broken: true } : m));
+							retryText = text;
 						} else {
 							error = msg;
 						}
@@ -245,13 +252,11 @@
 		} catch (e: unknown) {
 			if (e instanceof Error && e.name === 'AbortError') {
 				// User stopped — keep whatever was streamed
+			} else if (assistantIdx !== -1) {
+				messages = messages.map((m, i) => (i === assistantIdx ? { ...m, broken: true } : m));
+				retryText = text;
 			} else {
-				if (assistantIdx === -1) {
-					messages = messages.slice(0, -1);
-				} else {
-					messages = messages.filter((_, i) => i !== assistantIdx);
-					messages = messages.slice(0, -1);
-				}
+				messages = messages.slice(0, -1);
 				error = e instanceof Error ? e.message : 'Request failed';
 			}
 		} finally {
@@ -265,6 +270,17 @@
 			e.preventDefault();
 			send();
 		}
+	}
+
+	async function retry() {
+		if (!retryText) return;
+		const text = retryText;
+		retryText = null;
+		const brokenIdx = messages.findIndex((m) => m.broken);
+		if (brokenIdx !== -1) {
+			messages = messages.filter((_, i) => i !== brokenIdx && i !== brokenIdx - 1);
+		}
+		await send(text);
 	}
 
 	function clearConversation() {
@@ -412,12 +428,26 @@
 					{:else}
 						<div class="flex flex-col gap-1.5">
 							<div
-								class="rounded-2xl rounded-tl-sm bg-paper-ui px-4 py-3 font-sans text-sm leading-relaxed text-ink dark:bg-dark-paper-ui dark:text-dark-ink"
+								class="rounded-2xl rounded-tl-sm bg-paper-ui px-4 py-3 font-sans text-sm leading-relaxed text-ink dark:bg-dark-paper-ui dark:text-dark-ink {msg.broken
+									? 'opacity-50'
+									: ''}"
 								style="white-space: pre-wrap;"
 							>
 								{msg.content}
 							</div>
-							{#if msg.docsUsed && msg.docsUsed.length > 0}
+							{#if msg.broken}
+								<div class="flex items-center gap-2 pl-1">
+									<span class="font-sans text-xs text-ink-faint dark:text-dark-ink-faint"
+										>Response interrupted</span
+									>
+									<button
+										type="button"
+										onclick={retry}
+										class="font-sans text-xs text-accent underline decoration-dotted hover:decoration-solid"
+										>Retry</button
+									>
+								</div>
+							{:else if msg.docsUsed && msg.docsUsed.length > 0}
 								<div class="flex flex-wrap gap-1 pl-1">
 									{#each msg.docsUsed as doc (doc.id)}
 										<span
@@ -429,7 +459,7 @@
 								</div>
 							{/if}
 							<!-- Editor action cards — shown only after the last assistant message -->
-							{#if i === messages.length - 1 && pendingEditorActions.length > 0}
+							{#if i === messages.length - 1 && pendingEditorActions.length > 0 && !msg.broken}
 								{#each pendingEditorActions as action, j (j)}
 									<EditorActionCard
 										{action}
@@ -443,7 +473,7 @@
 									/>
 								{/each}
 							{/if}
-							{#if i === messages.length - 1 && pendingActions.length > 0}
+							{#if i === messages.length - 1 && pendingActions.length > 0 && !msg.broken}
 								{#each pendingActions as action, j (j)}
 									{#if action.type === 'propose_references'}
 										<ReferenceSelectCard
@@ -523,7 +553,7 @@
 			{:else}
 				<button
 					type="button"
-					onclick={send}
+					onclick={() => send()}
 					disabled={!input.trim()}
 					class="shrink-0 rounded-lg bg-accent p-1.5 text-white transition-colors hover:bg-accent-hover disabled:opacity-40"
 					aria-label="Send"

--- a/src/lib/server/trpc/routers/ai.ts
+++ b/src/lib/server/trpc/routers/ai.ts
@@ -98,6 +98,64 @@ async function throwProviderError(res: Response): Promise<never> {
 	throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message });
 }
 
+export function isNetworkError(e: unknown): boolean {
+	if (!(e instanceof Error)) return false;
+	const cause = (e as Error & { cause?: { message?: string } }).cause;
+	const text = (e.message + ' ' + (cause?.message ?? '')).toLowerCase();
+	return (
+		text.includes('input stream') ||
+		text.includes('fetch failed') ||
+		text.includes('socket') ||
+		text.includes('econnreset') ||
+		text.includes('connection reset') ||
+		text.includes('network error') ||
+		text.includes('failed to fetch')
+	);
+}
+
+async function openRouterStreamCall(
+	apiKey: string,
+	extraHeaders: Record<string, string>,
+	body: object,
+	onTextDelta: (chunk: string) => void,
+	onToolStart: ((name: string) => void) | undefined,
+	signal: AbortSignal | undefined
+): Promise<Awaited<ReturnType<typeof parseStreamingResponse>>> {
+	const MAX_RETRIES = 2;
+	for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+		let textStreamed = false;
+		try {
+			const res = await fetch(OPENROUTER_URL, {
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+					'Content-Type': 'application/json',
+					...extraHeaders
+				},
+				body: JSON.stringify(body),
+				signal
+			});
+			if (!res.ok) await throwProviderError(res);
+			return await parseStreamingResponse(
+				res,
+				(chunk) => {
+					textStreamed = true;
+					onTextDelta(chunk);
+				},
+				onToolStart,
+				signal
+			);
+		} catch (e) {
+			if (!textStreamed && isNetworkError(e) && attempt < MAX_RETRIES && !signal?.aborted) {
+				await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)));
+				continue;
+			}
+			throw e;
+		}
+	}
+	throw new Error('unreachable');
+}
+
 // ---------------------------------------------------------------------------
 // Project index  (~400 tokens, metadata only — no document content)
 // ---------------------------------------------------------------------------
@@ -1918,29 +1976,19 @@ export async function runAgentLoopSSE(
 
 	for (let i = 0; i < MAX_AGENT_ITERATIONS; i++) {
 		if (signal?.aborted) break;
-		const res = await fetch(OPENROUTER_URL, {
-			method: 'POST',
-			headers: {
-				Authorization: `Bearer ${apiKey}`,
-				'Content-Type': 'application/json',
-				...extraHeaders
-			},
-			body: JSON.stringify({
-				model,
-				max_tokens: 2048,
-				messages: [{ role: 'system', content: systemPrompt }, ...messages],
-				tools: TOOLS,
-				tool_choice: 'auto',
-				stream: true,
-				stream_options: { include_usage: true }
-			}),
-			signal
-		});
-		if (!res.ok) await throwProviderError(res);
-
 		const { content, toolCalls, inputTokens, outputTokens, finishReason } =
-			await parseStreamingResponse(
-				res,
+			await openRouterStreamCall(
+				apiKey,
+				extraHeaders,
+				{
+					model,
+					max_tokens: 2048,
+					messages: [{ role: 'system', content: systemPrompt }, ...messages],
+					tools: TOOLS,
+					tool_choice: 'auto',
+					stream: true,
+					stream_options: { include_usage: true }
+				},
 				(chunk) => write({ type: 'text_delta', content: chunk }),
 				(name) => write({ type: 'tool_start', name }),
 				signal
@@ -2089,29 +2137,19 @@ export async function runEditorAgentLoopSSE(
 
 	for (let i = 0; i < 4; i++) {
 		if (signal?.aborted) break;
-		const res = await fetch(OPENROUTER_URL, {
-			method: 'POST',
-			headers: {
-				Authorization: `Bearer ${apiKey}`,
-				'Content-Type': 'application/json',
-				...extraHeaders
-			},
-			body: JSON.stringify({
-				model,
-				max_tokens: 2048,
-				messages: [{ role: 'system', content: systemPrompt }, ...messages],
-				tools: activeTools,
-				tool_choice: 'auto',
-				stream: true,
-				stream_options: { include_usage: true }
-			}),
-			signal
-		});
-		if (!res.ok) await throwProviderError(res);
-
 		const { content, toolCalls, inputTokens, outputTokens, finishReason } =
-			await parseStreamingResponse(
-				res,
+			await openRouterStreamCall(
+				apiKey,
+				extraHeaders,
+				{
+					model,
+					max_tokens: 2048,
+					messages: [{ role: 'system', content: systemPrompt }, ...messages],
+					tools: activeTools,
+					tool_choice: 'auto',
+					stream: true,
+					stream_options: { include_usage: true }
+				},
 				(chunk) => write({ type: 'text_delta', content: chunk }),
 				(name) => write({ type: 'tool_start', name }),
 				signal

--- a/src/routes/(app)/projects/[id]/ai/+page.svelte
+++ b/src/routes/(app)/projects/[id]/ai/+page.svelte
@@ -24,6 +24,7 @@
 		role: 'user' | 'assistant' | 'system';
 		content: string;
 		docsUsed?: { id: string; title: string }[];
+		broken?: boolean;
 	};
 	let conversations = $derived(data.conversations ?? []);
 	let activeConvId = $state<string | null>(null);
@@ -33,6 +34,7 @@
 	let input = $state('');
 	let sending = $state(false);
 	let sendError = $state<string | null>(null);
+	let retryText = $state<string | null>(null);
 	let thinkingHint = $state('Thinking…');
 	let streamingMsgId = $state<string | null>(null);
 	let abortController = $state<AbortController | null>(null);
@@ -78,11 +80,13 @@
 		input = '';
 	}
 
-	async function send() {
-		const text = input.trim();
+	async function send(overrideText?: string) {
+		const text = (overrideText ?? input).trim();
 		if (!text || sending) return;
 
-		input = '';
+		retryText = null;
+		messages = messages.filter((m) => !m.broken);
+		if (!overrideText) input = '';
 		sending = true;
 		sendError = null;
 		pendingActions = [];
@@ -187,12 +191,18 @@
 					} else if (evt.type === 'error') {
 						const kind = evt.kind as string;
 						const msg = evt.message as string;
-						messages = messages.filter((m) => m.id !== localStreamId && m.id !== tempUserId);
-						streamingMsgId = null;
 						if (kind === 'system') {
+							messages = messages.filter((m) => m.id !== localStreamId && m.id !== tempUserId);
+							streamingMsgId = null;
 							messages = [...messages, { id: crypto.randomUUID(), role: 'system', content: msg }];
 							scrollToBottom();
+						} else if (localStreamId) {
+							messages = messages.map((m) => (m.id === localStreamId ? { ...m, broken: true } : m));
+							streamingMsgId = null;
+							retryText = text;
 						} else {
+							messages = messages.filter((m) => m.id !== localStreamId && m.id !== tempUserId);
+							streamingMsgId = null;
 							sendError = msg;
 						}
 					}
@@ -201,6 +211,10 @@
 		} catch (e) {
 			if (e instanceof Error && e.name === 'AbortError') {
 				// User stopped — keep whatever was streamed, just stop loading
+			} else if (localStreamId) {
+				messages = messages.map((m) => (m.id === localStreamId ? { ...m, broken: true } : m));
+				streamingMsgId = null;
+				retryText = text;
 			} else {
 				messages = messages.filter((m) => m.id !== localStreamId && m.id !== tempUserId);
 				streamingMsgId = null;
@@ -243,6 +257,17 @@
 			e.preventDefault();
 			send();
 		}
+	}
+
+	async function retry() {
+		if (!retryText) return;
+		const text = retryText;
+		retryText = null;
+		const brokenIdx = messages.findIndex((m) => m.broken);
+		if (brokenIdx !== -1) {
+			messages = messages.filter((_, i) => i !== brokenIdx && i !== brokenIdx - 1);
+		}
+		await send(text);
 	}
 
 	// ── Agent model selector ─────────────────────────────────────────────────
@@ -382,7 +407,7 @@
 											class="rounded-2xl px-4 py-3 font-sans text-sm leading-relaxed {msg.role ===
 											'user'
 												? 'rounded-tr-sm bg-accent text-white'
-												: 'chat-prose rounded-tl-sm bg-paper-ui text-ink dark:bg-dark-paper-ui dark:text-dark-ink'}"
+												: `chat-prose rounded-tl-sm bg-paper-ui text-ink dark:bg-dark-paper-ui dark:text-dark-ink${msg.broken ? ' opacity-50' : ''}`}"
 										>
 											{#if msg.role === 'assistant'}
 												<!-- eslint-disable-next-line svelte/no-at-html-tags -->
@@ -391,7 +416,19 @@
 												{msg.content}
 											{/if}
 										</div>
-										{#if msg.role === 'assistant' && msg.docsUsed?.length}
+										{#if msg.broken}
+											<div class="mt-1 flex items-center gap-2 px-1">
+												<span class="font-sans text-xs text-ink-faint dark:text-dark-ink-faint"
+													>Response interrupted</span
+												>
+												<button
+													type="button"
+													onclick={retry}
+													class="font-sans text-xs text-accent underline decoration-dotted hover:decoration-solid"
+													>Retry</button
+												>
+											</div>
+										{:else if msg.role === 'assistant' && msg.docsUsed?.length}
 											<div class="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 px-1">
 												<span class="font-sans text-[11px] text-ink-faint dark:text-dark-ink-faint"
 													>Sources:</span
@@ -406,7 +443,7 @@
 												{/each}
 											</div>
 										{/if}
-										{#if msg.id === lastAssistantMsgId && pendingActions.length > 0}
+										{#if msg.id === lastAssistantMsgId && pendingActions.length > 0 && !msg.broken}
 											{#each pendingActions as action, i (i)}
 												{#if action.type === 'propose_references'}
 													<ReferenceSelectCard
@@ -549,7 +586,7 @@
 						{:else}
 							<button
 								type="button"
-								onclick={send}
+								onclick={() => send()}
 								disabled={!input.trim()}
 								aria-label="Enviar"
 								class="shrink-0 rounded-lg bg-accent p-2 text-white transition-colors hover:bg-accent-hover disabled:opacity-40"

--- a/src/routes/api/projects/[id]/chat/+server.ts
+++ b/src/routes/api/projects/[id]/chat/+server.ts
@@ -9,6 +9,7 @@ import {
 	runAgentLoopSSE,
 	resolveTaskKey,
 	logUsage,
+	isNetworkError,
 	SYSTEM_PROMPT
 } from '$lib/server/trpc/routers/ai';
 import type { WithRLS } from '$lib/server/trpc/routers/ai';
@@ -144,12 +145,16 @@ export const POST: RequestHandler = async (event) => {
 			});
 		} catch (e) {
 			if (e instanceof Error && e.name === 'AbortError') return;
-			const msg = e instanceof Error ? e.message : 'Unknown error';
 			const isPreCondition =
 				e &&
 				typeof e === 'object' &&
 				'code' in e &&
 				(e as { code: string }).code === 'PRECONDITION_FAILED';
+			const msg = isNetworkError(e)
+				? 'The connection was interrupted. Please try again.'
+				: e instanceof Error
+					? e.message
+					: 'Unknown error';
 			send({ type: 'error', message: msg, kind: isPreCondition ? 'system' : 'banner' });
 		} finally {
 			await writer.close().catch(() => {});

--- a/src/routes/api/projects/[id]/documents/[docId]/chat/+server.ts
+++ b/src/routes/api/projects/[id]/documents/[docId]/chat/+server.ts
@@ -5,7 +5,12 @@ import type { RequestHandler } from './$types';
 import { db as rawDb } from '$lib/server/db';
 import { aiConversation, aiMessage } from '$lib/server/db/schemas/ai.schema';
 import { document } from '$lib/server/db/schemas/documents.schema';
-import { runEditorAgentLoopSSE, resolveTaskKey, logUsage } from '$lib/server/trpc/routers/ai';
+import {
+	runEditorAgentLoopSSE,
+	resolveTaskKey,
+	logUsage,
+	isNetworkError
+} from '$lib/server/trpc/routers/ai';
 import type { WithRLS } from '$lib/server/trpc/routers/ai';
 
 const bodySchema = z.object({
@@ -170,12 +175,16 @@ export const POST: RequestHandler = async (event) => {
 			});
 		} catch (e) {
 			if (e instanceof Error && e.name === 'AbortError') return;
-			const msg = e instanceof Error ? e.message : 'Unknown error';
 			const isPreCondition =
 				e &&
 				typeof e === 'object' &&
 				'code' in e &&
 				(e as { code: string }).code === 'PRECONDITION_FAILED';
+			const msg = isNetworkError(e)
+				? 'The connection was interrupted. Please try again.'
+				: e instanceof Error
+					? e.message
+					: 'Unknown error';
 			send({ type: 'error', message: msg, kind: isPreCondition ? 'system' : 'banner' });
 		} finally {
 			await writer.close().catch(() => {});


### PR DESCRIPTION
Adds friendly error messages and retry UX for when the OpenRouter connection drops mid-response (e.g. long bibliography queries).

- isNetworkError() detects socket/stream errors from undici
- openRouterStreamCall() retries up to 2x before text starts streaming
- Broken partial responses stay visible (dimmed) with a Retry button that re-sends the original message automatically
- Network errors shown as "The connection was interrupted" instead of the raw undici error string