### PR TITLE
fix(editor): make version banner always visible by moving it inside s…

### DIFF
--- a/src/lib/components/editor/NewVersionBanner.svelte
+++ b/src/lib/components/editor/NewVersionBanner.svelte
@@ -23,7 +23,7 @@
 </script>
 
 <div
-	class="flex items-center gap-3 border-b border-amber-200 bg-amber-50 px-6 py-2.5 dark:border-amber-700/40 dark:bg-amber-900/20"
+	class="flex items-center gap-3 bg-amber-50 px-6 py-2.5 dark:bg-amber-900/20"
 	role="status"
 	aria-live="polite"
 >

--- a/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
+++ b/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
@@ -2164,6 +2164,18 @@
 					</button>
 				{/if}
 			</div>
+
+			{#if newerVersion !== null}
+				<NewVersionBanner
+					type={newerVersion.type}
+					versionNumber={newerVersion.versionNumber}
+					committerName={newerVersion.committerName}
+					hasDirtyContent={isDirty}
+					onupdate={handleVersionUpdate}
+					onresolve={resolvingConflict ? undefined : handleResolveConflict}
+					ondismiss={handleVersionDismiss}
+				/>
+			{/if}
 		</div>
 
 		{#snippet editableTitle()}
@@ -2419,18 +2431,6 @@
 				{/if}
 			</div>
 		{/snippet}
-
-		{#if newerVersion !== null}
-			<NewVersionBanner
-				type={newerVersion.type}
-				versionNumber={newerVersion.versionNumber}
-				committerName={newerVersion.committerName}
-				hasDirtyContent={isDirty}
-				onupdate={handleVersionUpdate}
-				onresolve={resolvingConflict ? undefined : handleResolveConflict}
-				ondismiss={handleVersionDismiss}
-			/>
-		{/if}
 
 		<!-- Main layout -->
 		<div data-tutorial="doc-editor-area" class="flex min-h-0 flex-1 overflow-hidden">


### PR DESCRIPTION
…ticky toolbar

The banner was a sibling of the sticky toolbar in the flex-col container. If the page scrolled (e.g. on shorter viewports), the sticky toolbar remained fixed but the banner — not being sticky — scrolled out of view.

Fix: move the banner inside the sticky toolbar div as its last child row. It now sticks with the toolbar at all times regardless of scroll.

Also removed the banner's own border-b (border-amber-200) since the toolbar outer div already provides the bottom border that separates the header block from the content area.