### PR TITLE
fix(ai): send SSE heartbeat every 15s to prevent proxy idle timeout

### DIFF
--- a/src/routes/api/projects/[id]/chat/+server.ts
+++ b/src/routes/api/projects/[id]/chat/+server.ts
@@ -96,6 +96,7 @@ export const POST: RequestHandler = async (event) => {
 	const savedConvId = convId;
 
 	(async () => {
+		const heartbeat = setInterval(() => send({ type: 'ping' }), 15000);
 		try {
 			const result = await runAgentLoopSSE(
 				systemPrompt,
@@ -164,6 +165,7 @@ export const POST: RequestHandler = async (event) => {
 					: 'Unknown error';
 			send({ type: 'error', message: msg, kind: isPreCondition ? 'system' : 'banner' });
 		} finally {
+			clearInterval(heartbeat);
 			await writer.close().catch(() => {});
 		}
 	})();

--- a/src/routes/api/projects/[id]/documents/[docId]/chat/+server.ts
+++ b/src/routes/api/projects/[id]/documents/[docId]/chat/+server.ts
@@ -117,6 +117,7 @@ export const POST: RequestHandler = async (event) => {
 	const savedConvId = convId;
 
 	(async () => {
+		const heartbeat = setInterval(() => send({ type: 'ping' }), 15000);
 		try {
 			const result = await runEditorAgentLoopSSE(
 				documentTitle,
@@ -195,6 +196,7 @@ export const POST: RequestHandler = async (event) => {
 					: 'Unknown error';
 			send({ type: 'error', message: msg, kind: isPreCondition ? 'system' : 'banner' });
 		} finally {
+			clearInterval(heartbeat);
 			await writer.close().catch(() => {});
 		}
 	})();


### PR DESCRIPTION
The Fly.io proxy was closing connections when the agent loop spent >N seconds waiting for OpenRouter without emitting any SSE events (e.g. during tool calls before any text streamed). A ping event every 15s keeps the connection alive through the silent phases.