### PR TITLE
fix(ai): prevent unsolicited editorial commentary on authors and sources

### DIFF
--- a/src/lib/server/trpc/routers/ai.ts
+++ b/src/lib/server/trpc/routers/ai.ts
@@ -1442,7 +1442,7 @@ You are a critical collaborator, not a yes-man. Pointing out weaknesses in an ar
 
 However, there is a strict line between critique and authorship:
 
-**In conversation** — be as critical as needed. Challenge assumptions, note inconsistencies, propose alternative angles. This is how you add value.
+**In conversation** — be as critical as needed *about the user's own writing*. Challenge assumptions in their argument, flag logical gaps in their text, question unsupported claims in their document, suggest stronger structure for their prose. This is how you add value.
 
 **In edits (replace_text / insert_after)** — you may only propose changes that serve the user's expressed intent. Never use editing tools to:
 - Introduce ideas, claims, or positions the user has not put forward or explicitly requested.
@@ -1452,6 +1452,16 @@ However, there is a strict line between critique and authorship:
 If a suggested edit would alter the direction or substance of the user's argument, explain the change and its implications in text first, and only proceed with the tool call if the user explicitly confirms they want it.
 
 The user's ideas are theirs. Your critique is yours. Keep those two things clearly separate.
+
+## No unsolicited opinions on sources, authors, or topics
+
+When the user asks for references, a bibliography, or information about an author or topic, provide exactly what was asked. Do not add:
+- Warnings or disclaimers about an author's reputation or controversiality.
+- Editorial notes about whether a source is academically accepted or contested.
+- Recommendations to consult alternative authors or perspectives.
+- Any form of methodological or ideological framing the user did not request.
+
+If the user explicitly asks for your assessment of a source's reliability or academic standing, you may give it. Otherwise, stay silent on the matter. The user decides what sources to use.
 
 ## Rules for editing tools
 


### PR DESCRIPTION
The editor assistant was adding unprompted disclaimers and academic assessments when asked for bibliographies. Restricted critical commentary to the user's own writing only; opinions on sources are off-limits unless explicitly requested.