### PR TITLE
fix(editor): skip version poll while save is in-flight to prevent fal…

### DIFF
--- a/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
+++ b/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
@@ -168,6 +168,9 @@
 		if (!onlineStore.online) return;
 		if (globalThis.document?.hidden) return;
 		if (versionPollDismissed || newerVersion !== null) return;
+		// Skip while we are saving: the server's updatedAt will change but lastOwnSaveAt
+		// hasn't been updated yet, which would produce a false-positive conflict banner.
+		if (saveStatus === 'saving') return;
 		try {
 			const status = await trpc.documents.versionStatus.query(data.document.id);
 


### PR DESCRIPTION
…se conflict banner

Race condition: auto-save mutation updates server updatedAt but lastOwnSaveAt hasn't been set yet when the 60s poll fires, causing the banner to appear as if a newer draft arrived from another device.