### PR TITLE
feat(ai): resolve model catalog dynamically from OpenRouter instead o…

### DIFF
--- a/src/lib/ai-config.ts
+++ b/src/lib/ai-config.ts
@@ -22,169 +22,172 @@ export const AI_TASKS: {
 	label: string;
 	description: string;
 	hint: string;
-	defaultModel: string;
+	defaultFamily: string;
 }[] = [
 	{
 		id: 'agent',
 		label: 'Agent (chat)',
 		description: 'Conversational assistant with tool use',
 		hint: 'Needs tool calling support. A capable model like Sonnet or GPT-4o works best — it reasons, searches, and takes actions across your project.',
-		defaultModel: 'anthropic/claude-sonnet-4.6'
+		defaultFamily: 'claude-sonnet'
 	},
 	{
 		id: 'draft',
 		label: 'Draft',
 		description: 'Generate document drafts and sections',
 		hint: 'Benefits from a high-quality, long-context model. Gemini 2.5 Pro or Claude Sonnet handle long documents well.',
-		defaultModel: 'anthropic/claude-sonnet-4.6'
+		defaultFamily: 'claude-sonnet'
 	},
 	{
 		id: 'review',
 		label: 'Review',
 		description: 'Review and give feedback on documents',
 		hint: 'A reasoning-focused model gives better structured feedback. DeepSeek R1 or o3-mini are strong and affordable choices.',
-		defaultModel: 'deepseek/deepseek-r1'
+		defaultFamily: 'deepseek-r1'
 	},
 	{
 		id: 'requirements',
 		label: 'Requirements',
 		description: 'Generate project requirements',
 		hint: 'Needs structured output and logical thinking. Gemini Flash or DeepSeek V3 offer a good speed/quality balance.',
-		defaultModel: 'google/gemini-2.5-flash'
+		defaultFamily: 'gemini-flash'
 	},
 	{
 		id: 'bibliography',
 		label: 'Bibliography',
 		description: 'Extract bibliographic metadata from a URL',
 		hint: 'Simple extraction task — a fast, cheap model like Haiku is more than enough.',
-		defaultModel: 'anthropic/claude-haiku-4.5'
+		defaultFamily: 'claude-haiku'
 	},
 	{
 		id: 'spell',
 		label: 'Spell check',
 		description: 'On-demand spelling and grammar correction',
 		hint: 'Lightweight task. Any fast model works well; no need for a large or expensive one.',
-		defaultModel: 'anthropic/claude-haiku-4.5'
+		defaultFamily: 'claude-haiku'
 	},
 	{
 		id: 'grammar',
 		label: 'Grammar assistant',
 		description: 'Grammar and style suggestions for non-native English writers',
 		hint: 'Lightweight task. Haiku or Gemini Flash are ideal — fast and accurate enough for grammar corrections.',
-		defaultModel: 'anthropic/claude-haiku-4.5'
+		defaultFamily: 'claude-haiku'
 	},
 	{
 		id: 'summary',
 		label: 'Document summary',
 		description: 'AI summary generated on each commit for the project chat agent',
 		hint: 'Runs once per commit in the background. A fast, cheap model like Haiku is ideal — the summary is short and factual.',
-		defaultModel: 'anthropic/claude-haiku-4.5'
+		defaultFamily: 'claude-haiku'
 	}
 ];
 
-export function getDefaultModel(task: AiTask): string {
-	return AI_TASKS.find((t) => t.id === task)?.defaultModel ?? 'anthropic/claude-haiku-4.5';
-}
+// Model families — resolved dynamically against OpenRouter's live catalog
+// (see src/lib/server/openrouter.ts) instead of pinning exact ids, which drift
+// as OpenRouter renames/retires versions. Patterns are anchored ($) so they only
+// match the plain stable variant of a line (e.g. not "-preview" or "-image").
+export const MODEL_FAMILIES: { key: string; pattern: RegExp; label: string; shortLabel: string }[] =
+	[
+		{
+			key: 'claude-opus',
+			pattern: /^anthropic\/claude-opus-[\d.]+$/,
+			label: 'Claude Opus (best quality)',
+			shortLabel: 'Opus'
+		},
+		{
+			key: 'claude-sonnet',
+			pattern: /^anthropic\/claude-sonnet-[\d.]+$/,
+			label: 'Claude Sonnet',
+			shortLabel: 'Sonnet'
+		},
+		{
+			key: 'claude-haiku',
+			pattern: /^anthropic\/claude-haiku-[\d.]+$/,
+			label: 'Claude Haiku (fast)',
+			shortLabel: 'Haiku'
+		},
+		{
+			key: 'gemini-pro',
+			pattern: /^google\/gemini-[\d.]+-pro$/,
+			label: 'Gemini Pro (long context)',
+			shortLabel: 'Gemini Pro'
+		},
+		{
+			key: 'gemini-flash',
+			pattern: /^google\/gemini-[\d.]+-flash$/,
+			label: 'Gemini Flash (fast)',
+			shortLabel: 'Gemini Flash'
+		},
+		{
+			key: 'gpt-4o',
+			pattern: /^openai\/gpt-4o$/,
+			label: 'GPT-4o',
+			shortLabel: 'GPT-4o'
+		},
+		{
+			key: 'gpt-4o-mini',
+			pattern: /^openai\/gpt-4o-mini$/,
+			label: 'GPT-4o mini (fast)',
+			shortLabel: 'GPT-4o mini'
+		},
+		{
+			key: 'o3-mini',
+			pattern: /^openai\/o3-mini$/,
+			label: 'o3-mini (formal reasoning)',
+			shortLabel: 'o3-mini'
+		},
+		{
+			key: 'deepseek-r1',
+			pattern: /^deepseek\/deepseek-r1$/,
+			label: 'DeepSeek R1 (reasoning, affordable)',
+			shortLabel: 'DeepSeek R1'
+		},
+		{
+			key: 'deepseek-chat',
+			pattern: /^deepseek\/deepseek-chat$/,
+			label: 'DeepSeek V3 (affordable)',
+			shortLabel: 'DeepSeek V3'
+		},
+		{
+			key: 'llama-3.3-70b',
+			pattern: /^meta-llama\/llama-3\.3-70b-instruct$/,
+			label: 'Llama 3.3 70B (open source)',
+			shortLabel: 'Llama 3.3'
+		},
+		{
+			key: 'sonar',
+			pattern: /^perplexity\/sonar$/,
+			label: 'Perplexity Sonar (web search, fast)',
+			shortLabel: 'Sonar'
+		},
+		{
+			key: 'sonar-pro',
+			pattern: /^perplexity\/sonar-pro$/,
+			label: 'Perplexity Sonar Pro (web search)',
+			shortLabel: 'Sonar Pro'
+		}
+	];
 
-// Tasks for which each model is recommended (empty = no specific recommendation)
-// TODO issue #18: move to DB table so models can be added without redeploy
+// Tasks for which each model family is recommended (empty = no specific recommendation)
 export const MODEL_RECOMMENDATIONS: Record<string, AiTask[]> = {
-	'anthropic/claude-opus-4.5': ['agent', 'draft'],
-	'anthropic/claude-sonnet-4.6': ['agent', 'draft', 'review'],
-	'anthropic/claude-haiku-4.5': ['bibliography', 'spell', 'grammar', 'summary'],
-	'google/gemini-2.5-pro-preview': ['draft', 'review'],
-	'google/gemini-2.5-flash': ['requirements', 'summary'],
-	'openai/gpt-4o': ['agent', 'draft'],
-	'openai/o3-mini': ['review'],
-	'deepseek/deepseek-r1': ['review', 'requirements'],
-	'deepseek/deepseek-chat': ['draft', 'requirements']
+	'claude-opus': ['agent', 'draft'],
+	'claude-sonnet': ['agent', 'draft', 'review'],
+	'claude-haiku': ['bibliography', 'spell', 'grammar', 'summary'],
+	'gemini-pro': ['draft', 'review'],
+	'gemini-flash': ['requirements', 'summary'],
+	'gpt-4o': ['agent', 'draft'],
+	'o3-mini': ['review'],
+	'deepseek-r1': ['review', 'requirements'],
+	'deepseek-chat': ['draft', 'requirements']
 };
 
-export const MODELS: { id: string; label: string; shortLabel: string; toolCalling: boolean }[] = [
-	// Anthropic
-	{
-		id: 'anthropic/claude-opus-4.5',
-		label: 'Claude Opus 4 (best quality)',
-		shortLabel: 'Opus 4',
-		toolCalling: true
-	},
-	{
-		id: 'anthropic/claude-sonnet-4.6',
-		label: 'Claude Sonnet 4.6',
-		shortLabel: 'Sonnet 4.6',
-		toolCalling: true
-	},
-	{
-		id: 'anthropic/claude-haiku-4.5',
-		label: 'Claude Haiku 4.5 (fast)',
-		shortLabel: 'Haiku 4.5',
-		toolCalling: true
-	},
-	// Google
-	{
-		id: 'google/gemini-2.5-pro-preview',
-		label: 'Gemini 2.5 Pro (long context)',
-		shortLabel: 'Gemini 2.5 Pro',
-		toolCalling: true
-	},
-	{
-		id: 'google/gemini-2.5-flash',
-		label: 'Gemini 2.5 Flash (fast)',
-		shortLabel: 'Gemini 2.5 Flash',
-		toolCalling: true
-	},
-	// OpenAI
-	{ id: 'openai/gpt-4o', label: 'GPT-4o', shortLabel: 'GPT-4o', toolCalling: true },
-	{
-		id: 'openai/gpt-4o-mini',
-		label: 'GPT-4o mini (fast)',
-		shortLabel: 'GPT-4o mini',
-		toolCalling: true
-	},
-	{
-		id: 'openai/o3-mini',
-		label: 'o3-mini (formal reasoning)',
-		shortLabel: 'o3-mini',
-		toolCalling: false
-	},
-	// DeepSeek
-	{
-		id: 'deepseek/deepseek-r1',
-		label: 'DeepSeek R1 (reasoning, affordable)',
-		shortLabel: 'DeepSeek R1',
-		toolCalling: false
-	},
-	{
-		id: 'deepseek/deepseek-chat',
-		label: 'DeepSeek V3 (affordable)',
-		shortLabel: 'DeepSeek V3',
-		toolCalling: true
-	},
-	// Meta
-	{
-		id: 'meta-llama/llama-3.3-70b-instruct',
-		label: 'Llama 3.3 70B (open source)',
-		shortLabel: 'Llama 3.3',
-		toolCalling: true
-	},
-	// Perplexity (web search — no tool calling support)
-	{
-		id: 'perplexity/sonar',
-		label: 'Perplexity Sonar (web search, fast)',
-		shortLabel: 'Sonar',
-		toolCalling: false
-	},
-	{
-		id: 'perplexity/sonar-pro',
-		label: 'Perplexity Sonar Pro (web search)',
-		shortLabel: 'Sonar Pro',
-		toolCalling: false
-	}
-];
-
-export const MODEL_SHORT_LABEL = Object.fromEntries(MODELS.map((m) => [m.id, m.shortLabel]));
-
-export const TOOL_CALLING_MODELS = new Set(MODELS.filter((m) => m.toolCalling).map((m) => m.id));
+// Best-effort display label for an arbitrary (possibly historical, possibly no
+// longer "current") model id — e.g. usage logs and past conversations reference
+// exact ids that may not be in the live catalog anymore. No lookup table needed.
+export function formatModelSlug(id: string): string {
+	const slug = id.split('/').pop() ?? id;
+	return slug.replaceAll('-', ' ');
+}
 
 export function parseTaskConfig(raw: string | null): AiTaskConfig {
 	if (!raw) return {};

--- a/src/lib/components/ai/AiEditorPanel.svelte
+++ b/src/lib/components/ai/AiEditorPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { trpc } from '$lib/utils/trpc';
 	import { tick, onMount, untrack } from 'svelte';
-	import { MODELS } from '$lib/ai-config';
+	type ResolvedModel = { id: string; shortLabel: string; toolCalling: boolean };
 	import EditorActionCard from '$lib/components/ai/EditorActionCard.svelte';
 	import ReferenceSelectCard from '$lib/components/ai/ReferenceSelectCard.svelte';
 	import SafeDeleteDialog from '$lib/components/ui/SafeDeleteDialog.svelte';
@@ -33,7 +33,7 @@
 		defaultModel = ''
 	}: Props = $props();
 
-	const toolCallingModels = MODELS.filter((m) => m.toolCalling);
+	let toolCallingModels = $state<ResolvedModel[]>([]);
 	let selectedModel = $state(untrack(() => defaultModel));
 
 	type Message = {
@@ -93,6 +93,12 @@
 
 	onMount(() => {
 		fetch(`/api/projects/${projectId}/warm-index`, { method: 'POST' }).catch(() => {});
+		trpc.aiConfig.getModels
+			.query()
+			.then((models) => {
+				toolCallingModels = (models as ResolvedModel[]).filter((m) => m.toolCalling);
+			})
+			.catch(() => {});
 	});
 
 	let showClearDialog = $state(false);

--- a/src/lib/components/projects/OrgSettings.svelte
+++ b/src/lib/components/projects/OrgSettings.svelte
@@ -2,10 +2,17 @@
 	import { untrack } from 'svelte';
 	import { trpc } from '$lib/utils/trpc';
 	import { invalidateAll } from '$app/navigation';
-	import { AI_TASKS, MODELS, MODEL_RECOMMENDATIONS } from '$lib/ai-config';
+	import { AI_TASKS, MODEL_RECOMMENDATIONS } from '$lib/ai-config';
 	import { type OrgInvitationStatus, isInvitationPending } from '$lib/domain/invitation';
 
 	type Org = { id: string; name: string; slug: string; role: string };
+	type AiModel = {
+		id: string;
+		familyKey: string;
+		label: string;
+		toolCalling: boolean;
+		pricing: string | null;
+	};
 
 	let { initialOrgs }: { initialOrgs: Org[] } = $props();
 
@@ -26,6 +33,8 @@
 	let keys = $state<{ id: string; name: string; enabled: boolean; createdAt: Date }[]>([]);
 	let taskConfig = $state<Record<string, { keyId: string; model: string }>>({});
 	let loadingDetail = $state(false);
+	let aiModels = $state<AiModel[]>([]);
+	let aiModelsLoaded = $state(false);
 
 	// Invite form
 	let inviteEmail = $state('');
@@ -106,6 +115,13 @@
 
 	$effect(() => {
 		if (selectedOrgId) loadDetail(selectedOrgId);
+	});
+
+	$effect(() => {
+		if (!aiModelsLoaded) {
+			aiModelsLoaded = true;
+			trpc.aiConfig.getModels.query().then((m) => (aiModels = m as AiModel[]));
+		}
 	});
 
 	// ── Actions ───────────────────────────────────────────────────────────────
@@ -452,7 +468,7 @@
 											value={current?.keyId ?? ''}
 											onchange={(e) => {
 												const keyId = (e.target as HTMLSelectElement).value;
-												const model = current?.model ?? MODELS[0].id;
+												const model = current?.model ?? aiModels[0]?.id ?? '';
 												if (keyId) setTask(task.id, keyId, model);
 											}}
 											class="rounded-md border border-paper-border bg-paper px-2 py-1 font-sans text-xs text-ink focus:border-accent focus:outline-none dark:border-dark-paper-border dark:bg-dark-paper dark:text-dark-ink"
@@ -472,8 +488,8 @@
 											class="flex-1 rounded-md border border-paper-border bg-paper px-2 py-1 font-sans text-xs text-ink focus:border-accent focus:outline-none dark:border-dark-paper-border dark:bg-dark-paper dark:text-dark-ink"
 										>
 											<option value="">— model —</option>
-											{#each MODELS as model (model.id)}
-												{@const isRec = MODEL_RECOMMENDATIONS[model.id]?.includes(task.id)}
+											{#each aiModels as model (model.id)}
+												{@const isRec = MODEL_RECOMMENDATIONS[model.familyKey]?.includes(task.id)}
 												<option value={model.id}>{isRec ? '★ ' : ''}{model.label}</option>
 											{/each}
 										</select>

--- a/src/lib/components/settings/AiSettingsTab.svelte
+++ b/src/lib/components/settings/AiSettingsTab.svelte
@@ -2,7 +2,7 @@
 	import { untrack } from 'svelte';
 	import { trpc } from '$lib/utils/trpc';
 	import { invalidateAll } from '$app/navigation';
-	import { MODEL_RECOMMENDATIONS, MODEL_SHORT_LABEL } from '$lib/ai-config';
+	import { MODEL_RECOMMENDATIONS, formatModelSlug } from '$lib/ai-config';
 
 	import { resolve } from '$app/paths';
 	let {
@@ -26,14 +26,20 @@
 		label: string;
 		description: string;
 		hint: string;
-		defaultModel: string;
 	};
-	type AiModel = { id: string; label: string; toolCalling: boolean; pricing: string | null };
+	type AiModel = {
+		id: string;
+		familyKey: string;
+		label: string;
+		toolCalling: boolean;
+		pricing: string | null;
+	};
 
 	let aiKeys = $state<AiKey[]>([]);
 	let aiTaskConfig = $state<Partial<Record<AiTaskId, TaskConfig>>>({});
 	let aiModels = $state<AiModel[]>([]);
 	let aiTasks = $state<AiTaskDef[]>([]);
+	let aiDefaultModelIds = $state<Partial<Record<AiTaskId, string>>>({});
 	let aiObsoleteModels = $state<string[]>([]);
 	let loadingAi = $state(false);
 	let aiLoaded = $state(false);
@@ -77,6 +83,7 @@
 			aiTaskConfig = taskData.taskConfig as Partial<Record<AiTaskId, TaskConfig>>;
 			aiModels = models as AiModel[];
 			aiTasks = taskData.tasks as AiTaskDef[];
+			aiDefaultModelIds = taskData.defaultModelIds as Partial<Record<AiTaskId, string>>;
 			aiObsoleteModels = taskData.obsoleteModels;
 		} catch {
 			aiError = 'Could not load assistant configuration.';
@@ -562,13 +569,13 @@
 									class="flex-1 rounded-md border border-paper-border bg-paper px-2 py-1.5 font-sans text-sm text-ink focus:border-accent focus:outline-none dark:border-dark-paper-border dark:bg-dark-paper dark:text-dark-ink"
 								>
 									<option value=""
-										>— Default ({MODEL_SHORT_LABEL[task.defaultModel] ?? task.defaultModel}) —</option
+										>— Default ({formatModelSlug(aiDefaultModelIds[task.id as AiTaskId] ?? '')}) —</option
 									>
 									{#if cfg?.model && !aiModels.find((m) => m.id === cfg.model)}
 										<option value={cfg.model}>{cfg.model} (unavailable)</option>
 									{/if}
 									{#each task.id === 'agent' ? aiModels.filter((m) => m.toolCalling) : aiModels as m (m.id)}
-										{@const isRec = MODEL_RECOMMENDATIONS[m.id]?.includes(
+										{@const isRec = MODEL_RECOMMENDATIONS[m.familyKey]?.includes(
 											task.id as 'agent' | 'draft' | 'review' | 'requirements'
 										)}
 										<option value={m.id}

--- a/src/lib/components/usage/UsageDashboard.svelte
+++ b/src/lib/components/usage/UsageDashboard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { SvelteDate } from 'svelte/reactivity';
 	import { trpc } from '$lib/utils/trpc';
-	import { AI_TASKS, MODEL_SHORT_LABEL } from '$lib/ai-config';
+	import { AI_TASKS, formatModelSlug } from '$lib/ai-config';
 	import Spinner from '$lib/components/ui/Spinner.svelte';
 
 	import { resolve } from '$app/paths';
@@ -108,7 +108,7 @@
 	}
 
 	function modelLabel(model: string): string {
-		return MODEL_SHORT_LABEL[model] ?? model.split('/')[1] ?? model;
+		return formatModelSlug(model);
 	}
 
 	// ── SVG line chart ────────────────────────────────────────────────────────

--- a/src/lib/server/cache.ts
+++ b/src/lib/server/cache.ts
@@ -11,6 +11,7 @@
  *   scholio:s3:user:{userId}                       User S3 config     (TTL 10 min)
  *   scholio:s3:org:{orgId}                         Org S3 config      (TTL 10 min)
  *   scholio:photo:presign:{photoId}                Photo presigned URL (TTL 55 min)
+ *   scholio:model-catalog                          Resolved OpenRouter model catalog (TTL 5 days)
  */
 
 import Redis from 'ioredis';
@@ -24,7 +25,8 @@ export const TTL = {
 	taskKey: 5 * 60, // 5 min — decrypted AI key + model
 	s3Config: 10 * 60, // 10 min — decrypted S3 credentials
 	photoPresign: 55 * 60, // 55 min — presigned URL (valid for 60 min)
-	projectIndex: 60 // 60 s  — project index for AI agent
+	projectIndex: 60, // 60 s  — project index for AI agent
+	modelCatalog: 5 * 24 * 60 * 60 // 5 days — resolved OpenRouter model catalog
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -37,7 +39,8 @@ export const CACHE_KEY = {
 	userS3: (userId: string) => `scholio:s3:user:${userId}`,
 	orgS3: (orgId: string) => `scholio:s3:org:${orgId}`,
 	photoPresign: (photoId: string) => `scholio:photo:presign:${photoId}`,
-	projectIndex: (projectId: string) => `scholio:project-index:${projectId}`
+	projectIndex: (projectId: string) => `scholio:project-index:${projectId}`,
+	modelCatalog: () => 'scholio:model-catalog'
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/src/lib/server/openrouter.test.ts
+++ b/src/lib/server/openrouter.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// In-memory stand-in for Redis — lets tests control warm/cold cache scenarios
+// without a real Redis instance. There's no existing Redis-mocking precedent in
+// this repo, so this establishes the pattern: mock $lib/server/cache directly.
+const cacheStore = new Map<string, unknown>();
+
+vi.mock('$lib/server/cache', () => ({
+	cacheGet: vi.fn(async (key: string) => cacheStore.get(key) ?? null),
+	cacheSet: vi.fn(async (key: string, value: unknown) => {
+		cacheStore.set(key, value);
+	}),
+	CACHE_KEY: { modelCatalog: () => 'scholio:model-catalog' },
+	TTL: { modelCatalog: 5 * 24 * 60 * 60 }
+}));
+
+type FakeModel = {
+	id: string;
+	created: number;
+	toolCalling?: boolean;
+	input?: number;
+	output?: number;
+};
+
+function mockOpenRouterResponse(models: FakeModel[]) {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				data: models.map((m) => ({
+					id: m.id,
+					created: m.created,
+					pricing: {
+						prompt: String(m.input ?? 0.000001),
+						completion: String(m.output ?? 0.000002)
+					},
+					supported_parameters: m.toolCalling ? ['tools'] : []
+				}))
+			})
+		})
+	);
+}
+
+function mockOpenRouterFailure() {
+	vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+}
+
+// The module keeps an in-memory rawCache singleton — reset it between tests so
+// each scenario starts cold, matching a fresh server process.
+beforeEach(() => {
+	vi.resetModules();
+	cacheStore.clear();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
+
+describe('getModelCatalog: family resolution', () => {
+	it('picks the highest-created match within a family', async () => {
+		mockOpenRouterResponse([
+			{ id: 'anthropic/claude-sonnet-4.5', created: 100, toolCalling: true },
+			{ id: 'anthropic/claude-sonnet-4.6', created: 200, toolCalling: true }
+		]);
+		const { getModelCatalog } = await import('./openrouter');
+
+		const catalog = await getModelCatalog();
+		const sonnet = catalog.find((m) => m.familyKey === 'claude-sonnet');
+
+		expect(sonnet?.id).toBe('anthropic/claude-sonnet-4.6');
+	});
+
+	it('does not match "-preview"/"-image" variants against the anchored family pattern', async () => {
+		mockOpenRouterResponse([
+			{ id: 'google/gemini-2.5-pro-preview', created: 100 },
+			{ id: 'google/gemini-2.5-pro-image', created: 300 },
+			{ id: 'google/gemini-2.5-pro', created: 200 }
+		]);
+		const { getModelCatalog } = await import('./openrouter');
+
+		const catalog = await getModelCatalog();
+		const geminiPro = catalog.find((m) => m.familyKey === 'gemini-pro');
+
+		expect(geminiPro?.id).toBe('google/gemini-2.5-pro');
+	});
+
+	it('drops a family with zero matches instead of guessing', async () => {
+		mockOpenRouterResponse([
+			{ id: 'anthropic/claude-sonnet-4.6', created: 100, toolCalling: true }
+		]);
+		const { getModelCatalog } = await import('./openrouter');
+
+		const catalog = await getModelCatalog();
+
+		expect(catalog.find((m) => m.familyKey === 'gemini-pro')).toBeUndefined();
+		expect(catalog.find((m) => m.familyKey === 'claude-sonnet')).toBeDefined();
+	});
+
+	it('falls back to the safety-net model when the catalog resolves empty and the cache is cold', async () => {
+		mockOpenRouterFailure();
+		const { getModelCatalog } = await import('./openrouter');
+
+		const catalog = await getModelCatalog();
+
+		expect(catalog).toHaveLength(1);
+		expect(catalog[0].id).toBe('anthropic/claude-haiku-4.5');
+	});
+
+	it('does not cache the safety-net fallback in Redis', async () => {
+		mockOpenRouterFailure();
+		const { getModelCatalog } = await import('./openrouter');
+
+		await getModelCatalog();
+
+		expect(cacheStore.has('scholio:model-catalog')).toBe(false);
+	});
+});
+
+describe('getModelCatalog: Redis cache', () => {
+	it('serves from a warm Redis cache without refetching OpenRouter', async () => {
+		const warmCatalog = [
+			{
+				id: 'anthropic/claude-sonnet-4.6',
+				familyKey: 'claude-sonnet',
+				label: 'Claude Sonnet',
+				shortLabel: 'Sonnet',
+				toolCalling: true,
+				pricing: '$3.00/1M in · $15.00/1M out'
+			}
+		];
+		cacheStore.set('scholio:model-catalog', warmCatalog);
+		const fetchSpy = vi.fn();
+		vi.stubGlobal('fetch', fetchSpy);
+		const { getModelCatalog } = await import('./openrouter');
+
+		const catalog = await getModelCatalog();
+
+		expect(catalog).toEqual(warmCatalog);
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe('getDefaultModelId', () => {
+	it("resolves a task's default family to the current catalog id", async () => {
+		mockOpenRouterResponse([{ id: 'anthropic/claude-haiku-4.5', created: 100, toolCalling: true }]);
+		const { getDefaultModelId } = await import('./openrouter');
+
+		const model = await getDefaultModelId('bibliography'); // defaultFamily: 'claude-haiku'
+
+		expect(model).toBe('anthropic/claude-haiku-4.5');
+	});
+
+	it('falls back to the safety-net id when the resolved family is unavailable', async () => {
+		mockOpenRouterResponse([{ id: 'openai/gpt-4o', created: 100, toolCalling: true }]);
+		const { getDefaultModelId } = await import('./openrouter');
+
+		const model = await getDefaultModelId('bibliography'); // claude-haiku family absent from response
+
+		expect(model).toBe('anthropic/claude-haiku-4.5');
+	});
+});

--- a/src/lib/server/openrouter.ts
+++ b/src/lib/server/openrouter.ts
@@ -1,51 +1,153 @@
-// Shared OpenRouter API access — model pricing/catalog, cached in memory.
+// Shared OpenRouter API access — model catalog resolution, pricing, cached.
+//
+// Two layers of caching:
+//   - In-memory (module-level, 1h): the raw OpenRouter catalog fetch, shared by
+//     every function below so we only hit the network once per hour per instance.
+//   - Redis (5 days, via $lib/server/cache): the *resolved* per-family catalog
+//     (see MODEL_FAMILIES in $lib/ai-config), shared across instances. Redis
+//     being down/unset degrades gracefully to the in-memory layer (cache.ts
+//     already no-ops in that case).
 
-interface PricingCache {
-	fetchedAt: number;
-	prices: Record<string, { input: number; output: number }>;
+import { type AiTask, AI_TASKS, MODEL_FAMILIES } from '$lib/ai-config';
+import { cacheGet, cacheSet, CACHE_KEY, TTL } from '$lib/server/cache';
+
+// ---------------------------------------------------------------------------
+// Raw catalog fetch (in-memory cache, 1 hour)
+// ---------------------------------------------------------------------------
+
+interface RawModel {
+	id: string;
+	created: number;
+	pricing: { input: number; output: number };
+	toolCalling: boolean;
 }
 
-let pricingCache: PricingCache | null = null;
-const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+interface RawCatalogCache {
+	fetchedAt: number;
+	models: RawModel[];
+}
 
-export async function fetchOpenRouterPrices(): Promise<
-	Record<string, { input: number; output: number }>
-> {
-	if (pricingCache && Date.now() - pricingCache.fetchedAt < CACHE_TTL_MS) {
-		return pricingCache.prices;
+let rawCache: RawCatalogCache | null = null;
+const RAW_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+async function fetchRawCatalog(): Promise<RawModel[]> {
+	if (rawCache && Date.now() - rawCache.fetchedAt < RAW_CACHE_TTL_MS) {
+		return rawCache.models;
 	}
 
 	try {
 		const res = await fetch('https://openrouter.ai/api/v1/models', {
 			headers: { 'User-Agent': 'Scholio/1.0' }
 		});
-		if (!res.ok) return pricingCache?.prices ?? {};
+		if (!res.ok) return rawCache?.models ?? [];
 
 		const data = (await res.json()) as {
-			data: { id: string; pricing?: { prompt?: string; completion?: string } }[];
+			data: {
+				id: string;
+				created?: number;
+				pricing?: { prompt?: string; completion?: string };
+				supported_parameters?: string[];
+			}[];
 		};
 
-		const prices: Record<string, { input: number; output: number }> = {};
+		const models: RawModel[] = [];
 		for (const model of data.data) {
 			const input = parseFloat(model.pricing?.prompt ?? '0');
 			const output = parseFloat(model.pricing?.completion ?? '0');
-			if (!isNaN(input) && !isNaN(output)) {
-				prices[model.id] = { input, output };
-			}
+			if (isNaN(input) || isNaN(output)) continue;
+			models.push({
+				id: model.id,
+				created: model.created ?? 0,
+				pricing: { input, output },
+				toolCalling: model.supported_parameters?.includes('tools') ?? false
+			});
 		}
 
-		pricingCache = { fetchedAt: Date.now(), prices };
-		return prices;
+		rawCache = { fetchedAt: Date.now(), models };
+		return models;
 	} catch {
-		return pricingCache?.prices ?? {};
+		return rawCache?.models ?? [];
 	}
+}
+
+export async function fetchOpenRouterPrices(): Promise<
+	Record<string, { input: number; output: number }>
+> {
+	const models = await fetchRawCatalog();
+	return Object.fromEntries(models.map((m) => [m.id, m.pricing]));
 }
 
 // Returns the set of model ids currently served by OpenRouter, or null if we've
 // never had a successful fetch (so callers can distinguish "unknown" from "empty"
 // and avoid false positives when OpenRouter is unreachable).
 export async function getValidOpenRouterModelIds(): Promise<Set<string> | null> {
-	const prices = await fetchOpenRouterPrices();
-	if (!pricingCache) return null;
-	return new Set(Object.keys(prices));
+	const models = await fetchRawCatalog();
+	if (!rawCache) return null;
+	return new Set(models.map((m) => m.id));
+}
+
+function formatPrice(pricePerToken: number): string {
+	const perMillion = pricePerToken * 1_000_000;
+	if (perMillion === 0) return 'free';
+	if (perMillion < 0.01) return `$${(perMillion * 1000).toFixed(2)}/1B`;
+	if (perMillion < 1) return `$${perMillion.toFixed(3)}/1M`;
+	return `$${perMillion.toFixed(2)}/1M`;
+}
+
+// ---------------------------------------------------------------------------
+// Resolved per-family catalog (Redis cache, 5 days)
+// ---------------------------------------------------------------------------
+
+export interface ResolvedModel {
+	id: string;
+	familyKey: string;
+	label: string;
+	shortLabel: string;
+	toolCalling: boolean;
+	pricing: string | null;
+}
+
+// Last-resort fallback if the entire catalog resolution comes back empty
+// (OpenRouter unreachable AND no warm cache anywhere). Never cached in Redis —
+// see getModelCatalog — so we retry resolving the real catalog on the next call
+// rather than getting stuck serving this for the full 5-day TTL.
+const SAFETY_NET_MODEL: ResolvedModel = {
+	id: 'anthropic/claude-haiku-4.5',
+	familyKey: 'claude-haiku',
+	label: 'Claude Haiku (fast)',
+	shortLabel: 'Haiku',
+	toolCalling: true,
+	pricing: null
+};
+
+export async function getModelCatalog(): Promise<ResolvedModel[]> {
+	const cached = await cacheGet<ResolvedModel[]>(CACHE_KEY.modelCatalog());
+	if (cached && cached.length > 0) return cached;
+
+	const raw = await fetchRawCatalog();
+	const resolved: ResolvedModel[] = [];
+	for (const family of MODEL_FAMILIES) {
+		const matches = raw.filter((m) => family.pattern.test(m.id));
+		if (matches.length === 0) continue;
+		const best = matches.reduce((a, b) => (b.created > a.created ? b : a));
+		resolved.push({
+			id: best.id,
+			familyKey: family.key,
+			label: family.label,
+			shortLabel: family.shortLabel,
+			toolCalling: best.toolCalling,
+			pricing: `${formatPrice(best.pricing.input)} in · ${formatPrice(best.pricing.output)} out`
+		});
+	}
+
+	if (resolved.length === 0) return [SAFETY_NET_MODEL];
+
+	await cacheSet(CACHE_KEY.modelCatalog(), resolved, TTL.modelCatalog);
+	return resolved;
+}
+
+export async function getDefaultModelId(task: AiTask): Promise<string> {
+	const family = AI_TASKS.find((t) => t.id === task)?.defaultFamily;
+	const catalog = await getModelCatalog();
+	return catalog.find((m) => m.familyKey === family)?.id ?? SAFETY_NET_MODEL.id;
 }

--- a/src/lib/server/trpc/routers/ai.ts
+++ b/src/lib/server/trpc/routers/ai.ts
@@ -17,8 +17,8 @@ import {
 	organizationApiKey
 } from '$lib/server/db/schemas/organizations.schema';
 import { decryptSecret } from '$lib/server/kms';
-import { type AiTask, getDefaultModel, parseTaskConfig } from './aiConfig';
-import { fetchOpenRouterPrices } from '$lib/server/openrouter';
+import { type AiTask, parseTaskConfig } from './aiConfig';
+import { fetchOpenRouterPrices, getDefaultModelId } from '$lib/server/openrouter';
 import { indexDocument, embedQuery } from '$lib/server/embeddings';
 import { SUMMARY_MIN_CHARS } from '$lib/server/documentSummary';
 import type { Db } from '$lib/server/db';
@@ -894,7 +894,7 @@ export async function resolveTaskKey(
 	userId: string,
 	task: AiTask,
 	projectId?: string,
-	fallbackModel: string = getDefaultModel(task)
+	fallbackModel?: string
 ): Promise<{ apiKey: string; model: string; resolvedOrgId?: string }> {
 	const cacheKey = CACHE_KEY.taskKey(userId, task, projectId ?? '');
 	const cached = await cacheGet<{ apiKey: string; model: string; resolvedOrgId?: string }>(
@@ -970,7 +970,7 @@ export async function resolveTaskKey(
 						message: 'Error decrypting org API key.'
 					});
 				}
-				const model = orgTaskEntry?.model ?? fallbackModel;
+				const model = orgTaskEntry?.model ?? fallbackModel ?? (await getDefaultModelId(task));
 				const result = { apiKey, model, resolvedOrgId: orgId };
 				await cacheSet(cacheKey, result, TTL.taskKey);
 				return result;
@@ -1032,7 +1032,7 @@ export async function resolveTaskKey(
 		});
 	}
 
-	const model = taskEntry?.model ?? fallbackModel;
+	const model = taskEntry?.model ?? fallbackModel ?? (await getDefaultModelId(task));
 	const result = { apiKey, model };
 	await cacheSet(cacheKey, result, TTL.taskKey);
 	return result;
@@ -3060,8 +3060,7 @@ export const aiRouter = router({
 					ctx.db as Db,
 					userId,
 					'spell',
-					input.projectId,
-					'anthropic/claude-haiku-4.5'
+					input.projectId
 				).catch(() =>
 					resolveTaskKey(ctx.withRLS as WithRLS, ctx.db as Db, userId, 'agent', input.projectId)
 				),
@@ -3070,8 +3069,7 @@ export const aiRouter = router({
 					ctx.db as Db,
 					userId,
 					'grammar',
-					input.projectId,
-					'anthropic/claude-haiku-4.5'
+					input.projectId
 				).catch(() =>
 					resolveTaskKey(ctx.withRLS as WithRLS, ctx.db as Db, userId, 'agent', input.projectId)
 				)
@@ -3938,8 +3936,7 @@ Rules:
 				ctx.db,
 				userId,
 				'grammar',
-				input.projectId,
-				'anthropic/claude-haiku-4.5'
+				input.projectId
 			);
 
 			const prompt = `You are an expert English academic writing assistant helping non-native English speakers improve their writing.
@@ -4050,8 +4047,7 @@ ${input.text}`;
 				ctx.db,
 				userId,
 				'spell',
-				input.projectId,
-				'anthropic/claude-haiku-4.5'
+				input.projectId
 			);
 
 			// Fetch user allowlist (words previously rejected)

--- a/src/lib/server/trpc/routers/aiConfig.ts
+++ b/src/lib/server/trpc/routers/aiConfig.ts
@@ -4,44 +4,30 @@ import { TRPCError } from '@trpc/server';
 import { router, protectedProcedure } from '../init';
 import { userApiKey, userProfile } from '$lib/server/db/schemas/users.schema';
 import { encryptSecret } from '$lib/server/kms';
-import { fetchOpenRouterPrices, getValidOpenRouterModelIds } from '$lib/server/openrouter';
+import {
+	getValidOpenRouterModelIds,
+	getModelCatalog,
+	getDefaultModelId
+} from '$lib/server/openrouter';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 export type { AiTask, TaskConfig, AiTaskConfig } from '$lib/ai-config';
-export {
-	AI_TASKS,
-	MODELS,
-	TOOL_CALLING_MODELS,
-	parseTaskConfig,
-	getDefaultModel
-} from '$lib/ai-config';
+export { AI_TASKS, MODEL_FAMILIES, MODEL_RECOMMENDATIONS, parseTaskConfig } from '$lib/ai-config';
 import type { AiTask } from '$lib/ai-config';
-import { AI_TASKS, MODELS, parseTaskConfig } from '$lib/ai-config';
-
-function formatPrice(pricePerToken: number): string {
-	const perMillion = pricePerToken * 1_000_000;
-	if (perMillion === 0) return 'free';
-	if (perMillion < 0.01) return `$${(perMillion * 1000).toFixed(2)}/1B`;
-	if (perMillion < 1) return `$${perMillion.toFixed(3)}/1M`;
-	return `$${perMillion.toFixed(2)}/1M`;
-}
+import { AI_TASKS, parseTaskConfig } from '$lib/ai-config';
 
 // ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
 
 export const aiConfigRouter = router({
-	// Returns model list with live pricing from OpenRouter (cached 1h)
+	// Returns the resolved model catalog (family -> current OpenRouter id),
+	// cached 5 days in Redis — see getModelCatalog in $lib/server/openrouter.
 	getModels: protectedProcedure.query(async () => {
-		const prices = await fetchOpenRouterPrices();
-		return MODELS.map((m) => {
-			const p = prices[m.id];
-			const pricing = p ? `${formatPrice(p.input)} in · ${formatPrice(p.output)} out` : null;
-			return { ...m, pricing };
-		});
+		return getModelCatalog();
 	}),
 
 	// List all keys for the current user (no key material returned)
@@ -82,7 +68,10 @@ export const aiConfigRouter = router({
 		)) as { aiTaskConfig: string | null }[];
 
 		const taskConfig = parseTaskConfig(rows[0]?.aiTaskConfig ?? null);
-		const validModelIds = await getValidOpenRouterModelIds();
+		const [validModelIds, defaultModelIdEntries] = await Promise.all([
+			getValidOpenRouterModelIds(),
+			Promise.all(AI_TASKS.map(async (t) => [t.id, await getDefaultModelId(t.id)] as const))
+		]);
 		const obsoleteModels = validModelIds
 			? [...new Set(Object.values(taskConfig).map((c) => c.model))].filter(
 					(m) => !validModelIds.has(m)
@@ -91,8 +80,8 @@ export const aiConfigRouter = router({
 
 		return {
 			taskConfig,
-			models: MODELS,
 			tasks: AI_TASKS,
+			defaultModelIds: Object.fromEntries(defaultModelIdEntries) as Record<AiTask, string>,
 			obsoleteModels
 		};
 	}),

--- a/src/lib/server/trpc/routers/requirements.ts
+++ b/src/lib/server/trpc/routers/requirements.ts
@@ -7,7 +7,8 @@ import { projectRequirement } from '$lib/server/db/schemas/requirements.schema';
 import { project } from '$lib/server/db/schemas/projects.schema';
 import { userApiKey, userProfile } from '$lib/server/db/schemas/users.schema';
 import { decryptSecret } from '$lib/server/kms';
-import { parseTaskConfig, getDefaultModel } from './aiConfig';
+import { parseTaskConfig } from './aiConfig';
+import { getDefaultModelId } from '$lib/server/openrouter';
 import { coerceTemplate, canManageRequirements, type TemplateType } from '$lib/domain/requirements';
 import type { Db } from '$lib/server/db';
 
@@ -114,7 +115,7 @@ async function generateRequirementsFromAI(
 		});
 	}
 
-	const model = taskEntry?.model ?? getDefaultModel('requirements');
+	const model = taskEntry?.model ?? (await getDefaultModelId('requirements'));
 
 	const extraHeaders = {
 		'HTTP-Referer': env.ORIGIN ?? 'http://localhost:5174',

--- a/src/routes/(app)/projects/[id]/ai/+page.svelte
+++ b/src/routes/(app)/projects/[id]/ai/+page.svelte
@@ -10,10 +10,12 @@
 	import type { PendingAction } from '$lib/server/trpc/routers/ai';
 	import type { PageData } from './$types';
 	import SafeDeleteDialog from '$lib/components/ui/SafeDeleteDialog.svelte';
-	import { MODELS, MODEL_RECOMMENDATIONS } from '$lib/ai-config';
+	import { MODEL_RECOMMENDATIONS, formatModelSlug } from '$lib/ai-config';
 
 	import { resolve } from '$app/paths';
 	let { data }: { data: PageData } = $props();
+
+	type ResolvedModel = { id: string; familyKey: string; shortLabel: string; toolCalling: boolean };
 
 	onMount(() => {
 		fetch(`/api/projects/${data.project.id}/warm-index`, { method: 'POST' }).catch(() => {});
@@ -272,18 +274,16 @@
 
 	// ── Agent model selector ─────────────────────────────────────────────────
 	// Models available for the agent task: must support tool calling
-	const agentModels = MODELS.filter(
-		(m) => m.toolCalling && (MODEL_RECOMMENDATIONS[m.id]?.includes('agent') ?? true)
-	);
+	let agentModels = $state<ResolvedModel[]>([]);
 
 	// Configured model (from user Settings) — used as default
-	let configuredModel = $state<string>('anthropic/claude-sonnet-4.6');
+	let configuredModel = $state<string>('');
 	// Per-conversation override chosen in this session
 	let modelOverride = $state<string | null>(null);
 
 	const activeModel = $derived(modelOverride ?? configuredModel);
 	const activeModelLabel = $derived(
-		MODELS.find((m) => m.id === activeModel)?.shortLabel ?? activeModel
+		agentModels.find((m) => m.id === activeModel)?.shortLabel ?? formatModelSlug(activeModel)
 	);
 	const isOverridden = $derived(modelOverride !== null && modelOverride !== configuredModel);
 
@@ -291,11 +291,20 @@
 
 	async function loadAiConfig() {
 		try {
-			const taskData = await trpc.aiConfig.getTaskConfig.query();
+			const [taskData, models] = await Promise.all([
+				trpc.aiConfig.getTaskConfig.query(),
+				trpc.aiConfig.getModels.query()
+			]);
+			agentModels = (models as ResolvedModel[]).filter(
+				(m) => m.toolCalling && (MODEL_RECOMMENDATIONS[m.familyKey]?.includes('agent') ?? true)
+			);
 			const agentCfg = (taskData.taskConfig as Record<string, { keyId: string; model: string }>)[
 				'agent'
 			];
-			if (agentCfg?.model) configuredModel = agentCfg.model;
+			configuredModel =
+				agentCfg?.model ??
+				(taskData.defaultModelIds as Record<string, string>)['agent'] ??
+				configuredModel;
 		} catch {
 			// non-critical
 		}
@@ -703,8 +712,8 @@
 												}}
 												class="w-full rounded py-1.5 font-sans text-xs text-ink-faint transition-colors hover:text-ink dark:text-dark-ink-faint dark:hover:text-dark-ink"
 											>
-												Reset to default ({MODELS.find((m) => m.id === configuredModel)
-													?.shortLabel ?? configuredModel})
+												Reset to default ({agentModels.find((m) => m.id === configuredModel)
+													?.shortLabel ?? formatModelSlug(configuredModel)})
 											</button>
 										</div>
 									{/if}

--- a/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
+++ b/src/routes/(app)/projects/[id]/documents/[docId]/+page.svelte
@@ -39,7 +39,7 @@
 		type CitationStyle,
 		type CiteRef
 	} from '$lib/utils/citations';
-	import { MODEL_SHORT_LABEL } from '$lib/ai-config';
+	import { formatModelSlug } from '$lib/ai-config';
 	import { SPELL_LANGUAGES } from '$lib/spell-languages';
 	import {
 		getSaveDraftCapability,
@@ -1038,7 +1038,7 @@
 	);
 	function taskModel(task: 'agent' | 'draft' | 'review') {
 		const modelId = aiTaskConfig[task]?.model;
-		return modelId ? (MODEL_SHORT_LABEL[modelId] ?? modelId.split('/').pop() ?? '') : null;
+		return modelId ? formatModelSlug(modelId) : null;
 	}
 
 	// ── Chat assistant ───────────────────────────────────────────────────────────


### PR DESCRIPTION
…f hardcoded ids

Closes #331. We already hit the staleness bug once (claude-haiku-4-5 vs the real claude-haiku-4.5) and had to hand-patch it. Replace the fixed MODELS list with MODEL_FAMILIES — anchored regexes per model line (e.g. "the current Claude Sonnet") — resolved against OpenRouter's live catalog by picking the highest `created` match, cached in Redis for 5 days (cache.ts already has the TTL/cacheGet/cacheSet plumbing). A single hardcoded safety-net model covers total OpenRouter outages with a cold cache, and is never itself cached so resolution retries on the next call instead of getting stuck. The existing obsolete-model banner is untouched — it already worked off exact stored ids, orthogonal to family resolution.