### PR TITLE
perf(blog): disable client-side hydration on the public post page

### DIFF
--- a/src/routes/@[handle]/[slug]/+page.ts
+++ b/src/routes/@[handle]/[slug]/+page.ts
@@ -1,0 +1,8 @@
+// Public, static, SEO-focused page with no client interactivity (the
+// toolbar is plain <a> links) — skip hydration entirely. Ships pure
+// server-rendered HTML with no framework runtime, no inline hydration
+// payload duplicating the article content in a <script> tag, and no
+// hydration marker comments — simpler output for any consumer, and a
+// candidate fix for read-later services whose parser may choke on
+// SvelteKit's hydration scaffolding.
+export const csr = false;


### PR DESCRIPTION
The post page has zero interactive state — the toolbar is plain <a> links, nothing needs to react after first render. With csr=false, SvelteKit ships pure server-rendered HTML: no framework runtime, no modulepreload chain, and no inline hydration payload duplicating the full rendered article HTML inside a <script> tag.

Verified no regression: Mozilla Readability extracts the same content length before/after, and the page renders identically in the browser (screenshot-checked) despite shipping zero client JS for this route.

Also a plausible (untested) fix for the ongoing Instapaper parse failure — their parser is old enough that a large inline JSON blob containing a second copy of the article, plus the hydration comment markers, are exactly the kind of thing that trips up legacy scrapers. Worth a fresh Instapaper attempt once this is live.